### PR TITLE
Removed AnyCPU on some solution/project files

### DIFF
--- a/accounts/cs/accounts.csproj
+++ b/accounts/cs/accounts.csproj
@@ -8,7 +8,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}</ProjectGuid>
     <OutputType>AppContainerExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>

--- a/audiocreation/cs/audiocreation.sln
+++ b/audiocreation/cs/audiocreation.sln
@@ -9,7 +9,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CustomEffect", "CustomEffec
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM = Debug|ARM
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
@@ -19,7 +18,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|ARM.ActiveCfg = Debug|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|ARM.Build.0 = Debug|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|ARM.Deploy.0 = Debug|ARM
@@ -29,7 +27,6 @@ Global
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|x86.ActiveCfg = Debug|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|x86.Build.0 = Debug|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|x86.Deploy.0 = Debug|x86
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|Any CPU.ActiveCfg = Release|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|ARM.ActiveCfg = Release|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|ARM.Build.0 = Release|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|ARM.Deploy.0 = Release|ARM
@@ -39,14 +36,12 @@ Global
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|x86.ActiveCfg = Release|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|x86.Build.0 = Release|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|x86.Deploy.0 = Release|x86
-		{B55B67C8-A74F-4AE2-A3D5-6B076BD2777B}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{B55B67C8-A74F-4AE2-A3D5-6B076BD2777B}.Debug|ARM.ActiveCfg = Debug|ARM
 		{B55B67C8-A74F-4AE2-A3D5-6B076BD2777B}.Debug|ARM.Build.0 = Debug|ARM
 		{B55B67C8-A74F-4AE2-A3D5-6B076BD2777B}.Debug|x64.ActiveCfg = Debug|x64
 		{B55B67C8-A74F-4AE2-A3D5-6B076BD2777B}.Debug|x64.Build.0 = Debug|x64
 		{B55B67C8-A74F-4AE2-A3D5-6B076BD2777B}.Debug|x86.ActiveCfg = Debug|x86
 		{B55B67C8-A74F-4AE2-A3D5-6B076BD2777B}.Debug|x86.Build.0 = Debug|x86
-		{B55B67C8-A74F-4AE2-A3D5-6B076BD2777B}.Release|Any CPU.ActiveCfg = Release|x86
 		{B55B67C8-A74F-4AE2-A3D5-6B076BD2777B}.Release|ARM.ActiveCfg = Release|ARM
 		{B55B67C8-A74F-4AE2-A3D5-6B076BD2777B}.Release|ARM.Build.0 = Release|ARM
 		{B55B67C8-A74F-4AE2-A3D5-6B076BD2777B}.Release|x64.ActiveCfg = Release|x64

--- a/backgroundaudio/cs/backgroundaudio.sln
+++ b/backgroundaudio/cs/backgroundaudio.sln
@@ -11,7 +11,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BackgroundAudioShared", "Ba
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM = Debug|ARM
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
@@ -21,9 +20,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|ARM.ActiveCfg = Debug|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|ARM.Build.0 = Debug|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|ARM.Deploy.0 = Debug|ARM
@@ -33,9 +29,6 @@ Global
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|x86.ActiveCfg = Debug|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|x86.Build.0 = Debug|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|x86.Deploy.0 = Debug|x86
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|ARM.ActiveCfg = Release|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|ARM.Build.0 = Release|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|ARM.Deploy.0 = Release|ARM

--- a/backgroundaudio/cs/backgroundaudio/backgroundaudio.csproj
+++ b/backgroundaudio/cs/backgroundaudio/backgroundaudio.csproj
@@ -24,25 +24,6 @@
     <AppxBundle>Auto</AppxBundle>
     <AppxBundlePlatforms>neutral</AppxBundlePlatforms>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UAP</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UAP</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\ARM\Debug\</OutputPath>

--- a/backgroundtask/cs/tasks/tasks.csproj
+++ b/backgroundtask/cs/tasks/tasks.csproj
@@ -16,23 +16,6 @@
     <TargetFrameworkProfile>Profile32</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->
   </ItemGroup>

--- a/edpsamples/cs/Tasks/Tasks.csproj
+++ b/edpsamples/cs/Tasks/Tasks.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{95949F93-D529-46BF-80C4-89BF27AA4D47}</ProjectGuid>
     <OutputType>winmdobj</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -16,25 +16,6 @@
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UAP</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UAP</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <PlatformTarget>ARM</PlatformTarget>

--- a/edpsamples/cs/edpsamples.sln
+++ b/edpsamples/cs/edpsamples.sln
@@ -9,7 +9,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tasks", "Tasks\Tasks.csproj
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM = Debug|ARM
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
@@ -19,7 +18,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|ARM.ActiveCfg = Debug|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|ARM.Build.0 = Debug|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|ARM.Deploy.0 = Debug|ARM
@@ -29,7 +27,6 @@ Global
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|x86.ActiveCfg = Debug|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|x86.Build.0 = Debug|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|x86.Deploy.0 = Debug|x86
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|Any CPU.ActiveCfg = Release|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|ARM.ActiveCfg = Release|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|ARM.Build.0 = Release|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|ARM.Deploy.0 = Release|ARM
@@ -39,16 +36,12 @@ Global
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|x86.ActiveCfg = Release|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|x86.Build.0 = Release|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|x86.Deploy.0 = Release|x86
-		{95949F93-D529-46BF-80C4-89BF27AA4D47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{95949F93-D529-46BF-80C4-89BF27AA4D47}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{95949F93-D529-46BF-80C4-89BF27AA4D47}.Debug|ARM.ActiveCfg = Debug|ARM
 		{95949F93-D529-46BF-80C4-89BF27AA4D47}.Debug|ARM.Build.0 = Debug|ARM
 		{95949F93-D529-46BF-80C4-89BF27AA4D47}.Debug|x64.ActiveCfg = Debug|x64
 		{95949F93-D529-46BF-80C4-89BF27AA4D47}.Debug|x64.Build.0 = Debug|x64
 		{95949F93-D529-46BF-80C4-89BF27AA4D47}.Debug|x86.ActiveCfg = Debug|x86
 		{95949F93-D529-46BF-80C4-89BF27AA4D47}.Debug|x86.Build.0 = Debug|x86
-		{95949F93-D529-46BF-80C4-89BF27AA4D47}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{95949F93-D529-46BF-80C4-89BF27AA4D47}.Release|Any CPU.Build.0 = Release|Any CPU
 		{95949F93-D529-46BF-80C4-89BF27AA4D47}.Release|ARM.ActiveCfg = Release|ARM
 		{95949F93-D529-46BF-80C4-89BF27AA4D47}.Release|ARM.Build.0 = Release|ARM
 		{95949F93-D529-46BF-80C4-89BF27AA4D47}.Release|x64.ActiveCfg = Release|x64

--- a/screencasting/cs/Screen Casting - Build 2015.csproj
+++ b/screencasting/cs/Screen Casting - Build 2015.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}</ProjectGuid>
     <OutputType>AppContainerExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -24,25 +24,6 @@
     <PackageCertificateKeyFile>Combining Casting Tech_TemporaryKey.pfx</PackageCertificateKeyFile>
     <!--
     -->
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UAP</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UAP</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>

--- a/screencasting/cs/Screen Casting - Build 2015.sln
+++ b/screencasting/cs/Screen Casting - Build 2015.sln
@@ -7,7 +7,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Screen Casting - Build 2015
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM = Debug|ARM
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
@@ -17,9 +16,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|ARM.ActiveCfg = Debug|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|ARM.Build.0 = Debug|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|ARM.Deploy.0 = Debug|ARM
@@ -29,9 +25,6 @@ Global
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|x86.ActiveCfg = Debug|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|x86.Build.0 = Debug|x86
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Debug|x86.Deploy.0 = Debug|x86
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|ARM.ActiveCfg = Release|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|ARM.Build.0 = Release|ARM
 		{DC30CE66-DAEE-4CCF-BD02-8837FE918B6F}.Release|ARM.Deploy.0 = Release|ARM

--- a/xaml_masterdetail/CS/MasterDetailApp.csproj
+++ b/xaml_masterdetail/CS/MasterDetailApp.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}</ProjectGuid>
     <OutputType>AppContainerExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -21,25 +21,6 @@
     <AppxPackageSigningEnabled>true</AppxPackageSigningEnabled>
     <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
     <AppxBundlePlatforms>x86|arm</AppxBundlePlatforms>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UAP</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UAP</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>

--- a/xaml_masterdetail/CS/MasterDetailApp.sln
+++ b/xaml_masterdetail/CS/MasterDetailApp.sln
@@ -7,19 +7,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MasterDetailApp", "MasterDe
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM = Debug|ARM
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|Any CPU = Release|Any CPU
 		Release|ARM = Release|ARM
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Debug|ARM.ActiveCfg = Debug|ARM
 		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Debug|ARM.Build.0 = Debug|ARM
 		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Debug|ARM.Deploy.0 = Debug|ARM
@@ -29,9 +24,6 @@ Global
 		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Debug|x86.ActiveCfg = Debug|x86
 		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Debug|x86.Build.0 = Debug|x86
 		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Debug|x86.Deploy.0 = Debug|x86
-		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Release|ARM.ActiveCfg = Release|ARM
 		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Release|ARM.Build.0 = Release|ARM
 		{FBAE9E89-C6EE-4C73-B7DF-6696412B1CFB}.Release|ARM.Deploy.0 = Release|ARM


### PR DESCRIPTION
As Unni discussed during his //BUILD/ talk, AnyCPU is no longer supported for C# UWP apps. I removed the AnyCPU profile from several solution/project files to bring these in line with the VS 2015 RC project templates and to prevent users from using this profile by accident and getting an error when they want to debug.

As the VS 2015 RC JS projects still seem to support AnyCPU, I didn't update those.
*Note: some files showed as completely changed (probably line endings or encoding), I didn't check these in to prevent confusion.*