### PR TITLE
Fix crash in GetPreviewFrame when return from suspension

### DIFF
--- a/CameraGetPreviewFrame/cpp/MainPage.xaml.cpp
+++ b/CameraGetPreviewFrame/cpp/MainPage.xaml.cpp
@@ -490,10 +490,10 @@ void MainPage::Application_Suspending(Object^, Windows::ApplicationModel::Suspen
     // Handle global application events only if this page is active
     if (Frame->CurrentSourcePageType.Name == Interop::TypeName(MainPage::typeid).Name)
     {
+        auto deferral = e->SuspendingOperation->GetDeferral();
         CleanupCameraAsync()
-            .then([this, e]()
+            .then([this, deferral]()
         {
-            auto deferral = e->SuspendingOperation->GetDeferral();
             _displayInformation->OrientationChanged -= _displayInformationEventToken;
             deferral->Complete();   
         });


### PR DESCRIPTION
Just needed to grab the deferral object before it went away.