### PR TITLE
Update Transform3DParallax.csproj

### DIFF
--- a/Samples/XamlTransform3DParallax/cs/Transform3DParallax.csproj
+++ b/Samples/XamlTransform3DParallax/cs/Transform3DParallax.csproj
@@ -91,7 +91,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\..\SharedContent\xaml\App.xaml.cs">
+    <Compile Include="..\..\..\SharedContent\cs\App.xaml.cs">
       <Link>App.xaml.cs</Link>
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
The App.xaml.cs is pointing to the wrong folder at ApplicationDefinition Include="..\..\..\SharedContent\xaml\App.xaml"

It should be:
ApplicationDefinition Include="..\..\..\SharedContent\cs\App.xaml"