### PR TITLE
Fixing "The 'ToastCapable' attribute is not declared." error in Package.appxmanifest

### DIFF
--- a/Samples/SocketActivityStreamSocket/cs/SocketActivityStreamSocket/Package.appxmanifest
+++ b/Samples/SocketActivityStreamSocket/cs/SocketActivityStreamSocket/Package.appxmanifest
@@ -37,9 +37,7 @@
               Square150x150Logo="Assets\SquareTile-sdk.png"
               Square44x44Logo="Assets\SmallTile-sdk.png"
               Description="SocketActivityStreamSocket"
-              
-              BackgroundColor="#00b2f0"
-              ToastCapable="true">
+              BackgroundColor="#00b2f0">
                 <uap:SplashScreen Image="Assets\Splash-sdk.png" />
                 <uap:DefaultTile>
                     <uap:ShowNameOnTiles>


### PR DESCRIPTION
Without this fix, "Create App Package" fails with:

    ---------------------------
    Microsoft Visual Studio
    ---------------------------
    Unable to build an app package because the app manifest is invalid. 
    Correct the errors in the app manifest.
    ---------------------------
    OK
    ---------------------------