### PR TITLE
Fixed crash in XamlBind sample by changing binding

### DIFF
--- a/Samples/XamlBind/cs/OtherBindings.xaml
+++ b/Samples/XamlBind/cs/OtherBindings.xaml
@@ -88,7 +88,7 @@
                     <TextBlock Grid.Row="2" Grid.Column="1" Text="{x:Bind LocalTextBox.Text.Length, Mode=OneWay}"/>
 
                     <TextBlock Grid.Row="3" Text="Text and FontSize are both bound"/>
-                    <TextBlock Grid.Row="3" Grid.Column="1" Text="{x:Bind LocalTextBox.Text, Mode=OneWay}" FontSize="{x:Bind Model.IntPropWithINPC, Mode=OneWay}" />
+                    <TextBlock Grid.Row="3" Grid.Column="1" Text="{x:Bind LocalTextBox.Text, Mode=OneWay}" FontSize="{x:Bind LocalTextBox.Text.Length, Mode=OneWay}" />
                 </Grid>
 
                 <TextBlock Style="{StaticResource Note}"><Run>The following is a grid panel with rectangles with bindings to the Grid.Column property</Run></TextBlock>


### PR DESCRIPTION
Changed a binding in OtherBindings.xaml to fix a crash. Previously the FontSize of a TextBlock was bound to Model.IntPropWithINPC, which caused a crash when that value went to zero (by dragging the corresponding slider all the way to the left).

With this change the FontSize is bound instead to the text length, and doesn't crash even when the length goes to zero. Tested in Desktop build 10240.