### PR TITLE
Adapted to work on all W10 devices and form factors in the same way

### DIFF
--- a/Samples/SplashScreen/cs/ExtendedSplash.xaml
+++ b/Samples/SplashScreen/cs/ExtendedSplash.xaml
@@ -18,9 +18,9 @@
         <RowDefinition Height="180"/>
     </Grid.RowDefinitions>
 
-    <Viewbox Grid.Row="0" Grid.RowSpan="2" Stretch="Uniform">
-        <Image x:Name="extendedSplashImage" Source="Assets/splash-Phone-sdk.png"/>
-    </Viewbox>
+    <Canvas Grid.Row="0" Grid.RowSpan="2">
+        <Image x:Name="extendedSplashImage" Source="Assets/splash-sdk.png"/>
+    </Canvas>
     <StackPanel Grid.Row="1" HorizontalAlignment="Center">
         <TextBlock Style="{StaticResource BasicTextStyle}" TextWrapping="Wrap" TextAlignment="Center" Padding="5" HorizontalAlignment="Center">
        The splash screen was dismissed and the image above was positioned using the splash screen API.

--- a/Samples/SplashScreen/cs/ExtendedSplash.xaml.cs
+++ b/Samples/SplashScreen/cs/ExtendedSplash.xaml.cs
@@ -13,6 +13,7 @@ using System;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Activation;
 using Windows.Foundation;
+using Windows.Graphics.Display;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -28,6 +29,7 @@ namespace SplashScreenSample
         internal Frame rootFrame;
 
         private SplashScreen splash; // Variable to hold the splash screen object.
+        private double ScaleFactor; //Variable to hold the device scale factor (use to determine phone screen resolution)
 
         public ExtendedSplash(SplashScreen splashscreen, bool loadState)
         {
@@ -37,6 +39,8 @@ namespace SplashScreenSample
             // Listen for window resize events to reposition the extended splash screen image accordingly.
             // This is important to ensure that the extended splash screen is formatted properly in response to snapping, unsnapping, rotation, etc...
             Window.Current.SizeChanged += new WindowSizeChangedEventHandler(ExtendedSplash_OnResize);
+
+            ScaleFactor = (double)DisplayInformation.GetForCurrentView().ResolutionScale / 100;
 
             splash = splashscreen;
 
@@ -70,22 +74,10 @@ namespace SplashScreenSample
         // Position the extended splash screen image in the same location as the system splash screen image.
         void PositionImage()
         {
-            if (Windows.Foundation.Metadata.ApiInformation.IsTypePresent("Windows.Phone.UI.Input.HardwareButtons"))
-            {
-                extendedSplashImage.SetValue(Viewbox.HeightProperty, splashImageRect.Height);
-                extendedSplashImage.SetValue(Viewbox.WidthProperty, splashImageRect.Width);
-                // Since we are on Phone we use a "portrait-layout" image to load into.
-                extendedSplashImage.Source = new Windows.UI.Xaml.Media.Imaging.BitmapImage(new Uri(extendedSplashImage.BaseUri, "Images/extended-splash-Phone-sdk.png"));
-            }
-            else
-            {
-                extendedSplashImage.SetValue(Viewbox.HeightProperty, splashImageRect.X);
-                extendedSplashImage.SetValue(Viewbox.HeightProperty, splashImageRect.Y);
-                extendedSplashImage.Height = splashImageRect.Height;
-                extendedSplashImage.Width = splashImageRect.Width;
-                // Since we are not on Phone we use a standard "wide-layout" image to load into.
-                extendedSplashImage.Source = new Windows.UI.Xaml.Media.Imaging.BitmapImage(new Uri(extendedSplashImage.BaseUri, "Images/extended-splash-Windows-sdk.png"));
-            }
+            extendedSplashImage.SetValue(Canvas.LeftProperty, splashImageRect.Left);
+            extendedSplashImage.SetValue(Canvas.TopProperty, splashImageRect.Top);
+            extendedSplashImage.Height = splashImageRect.Height / ScaleFactor;
+            extendedSplashImage.Width = splashImageRect.Width / ScaleFactor;
         }
 
         void ExtendedSplash_OnResize(Object sender, WindowSizeChangedEventArgs e)

--- a/Samples/SplashScreen/cs/Package.appxmanifest
+++ b/Samples/SplashScreen/cs/Package.appxmanifest
@@ -17,7 +17,7 @@
   <Applications>
     <Application Id="SplashScreen.App" Executable="$targetnametoken$.exe" EntryPoint="SplashScreen.App">
       <uap:VisualElements DisplayName="SplashScreen C# sample" Square150x150Logo="Assets\squareTile-sdk.png" Square44x44Logo="Assets\SmallTile-sdk.png" Description="SplashScreen C# sample" BackgroundColor="#00b2f0">
-        <uap:SplashScreen Image="Assets\Splash-sdk.png" />
+        <uap:SplashScreen Image="Assets\Splash-sdk.png" BackgroundColor="#00B2F0" />
         <uap:DefaultTile>
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo" />


### PR DESCRIPTION
I've adapted the sample to work as a Universal app. There is no need to use separate images and code for PC/tablets and phones. The main changes are:

1) Use Canvas instead of Viewbox: it might work with Viewbox as well, but couldn't find a reliable way
2) Use DisplayInformation.GetForCurrentView().ResolutionScale to calculate the appropriate form factor for the image (AFAIK on phones the splashImageRect numbers are referred to the base resolution and have to be scaled to match the actual device resolution)
3) Make use only of one image (Asset/splash-sdk.png), no need to have a separate portrait version for phones

I've tested it on a Surface Pro 3 and on three of the emulators coming with VS2015 (WVGA, WXGA and 1028p).

Please fell free to use all or part or nothing of my proposed code. Thanks for your all your effort with these samples.