### PR TITLE
Removed unnecessary comma from "ControlInfoData.json" that was causin…

### DIFF
--- a/Samples/XamlUIBasics/cs/AppUIBasics/DataModel/ControlInfoData.json
+++ b/Samples/XamlUIBasics/cs/AppUIBasics/DataModel/ControlInfoData.json
@@ -478,7 +478,7 @@
                     "Content": "<p>Look at the <i>SplitViewPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
                     "Docs": [
                         { "Title": "SplitView", "Uri": "http://msdn.microsoft.com/library/windows/apps/windows.ui.xaml.controls.splitview.aspx" },
-                        { "Title": "Hamburger pattern", "Uri": "http://go.microsoft.com/fwlink/p/?LinkId=619902&clcid=0x409" },
+                        { "Title": "Hamburger pattern", "Uri": "http://go.microsoft.com/fwlink/p/?LinkId=619902&clcid=0x409" }
                     ],
                     "RelatedControls": [
                         "StackPanel",


### PR DESCRIPTION
The sample "AppUIBasics" throws an error (invalid JSON string at character 39908) when the app starts due to a unecessary comma in the ControlInfoData.json file (line 481).