### PR TITLE
Fixed some coding style issues in ApplicationData solution.

### DIFF
--- a/Samples/ApplicationData/cs/App.xaml.cs
+++ b/Samples/ApplicationData/cs/App.xaml.cs
@@ -31,8 +31,8 @@ namespace SDKTemplate
         /// </summary>
         public App()
         {
-            this.InitializeComponent();
-            this.Suspending += OnSuspending;
+            InitializeComponent();
+            Suspending += OnSuspending;
         }
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace SDKTemplate
 #if DEBUG
             if (System.Diagnostics.Debugger.IsAttached)
             {
-                this.DebugSettings.EnableFrameRateCounter = false;
+                DebugSettings.EnableFrameRateCounter = false;
             }
 #endif
 

--- a/Samples/ApplicationData/cs/MainPage.xaml.cs
+++ b/Samples/ApplicationData/cs/MainPage.xaml.cs
@@ -30,7 +30,7 @@ namespace SDKTemplate
 
         public MainPage()
         {
-            this.InitializeComponent();
+            InitializeComponent();
 
             // This is a static public property that allows downstream pages to get a handle to the MainPage instance
             // in order to call methods that are in this class.
@@ -42,14 +42,7 @@ namespace SDKTemplate
         {
             // Populate the scenario list from the SampleConfiguration.cs file
             ScenarioControl.ItemsSource = scenarios;
-            if (Window.Current.Bounds.Width < 640)
-            {
-                ScenarioControl.SelectedIndex = -1;
-            }
-            else
-            {
-                ScenarioControl.SelectedIndex = 0;
-            }
+            ScenarioControl.SelectedIndex = Window.Current.Bounds.Width < 640 ? -1 : 0;
         }
 
         /// <summary>
@@ -65,20 +58,25 @@ namespace SDKTemplate
 
             ListBox scenarioListBox = sender as ListBox;
             Scenario s = scenarioListBox.SelectedItem as Scenario;
-            if (s != null)
+            if (s == null)
             {
-                ScenarioFrame.Navigate(s.ClassType);
-                if (Window.Current.Bounds.Width < 640)
-                {
-                    Splitter.IsPaneOpen = false;
-                    StatusBorder.Visibility = Visibility.Collapsed;
-                }
+                return;
+            }
+
+            ScenarioFrame.Navigate(s.ClassType);
+            if (Window.Current.Bounds.Width < 640)
+            {
+                Splitter.IsPaneOpen = false;
+                StatusBorder.Visibility = Visibility.Collapsed;
             }
         }
 
         public List<Scenario> Scenarios
         {
-            get { return this.scenarios; }
+            get
+            {
+                return scenarios;
+            }
         }
 
         /// <summary>
@@ -100,7 +98,7 @@ namespace SDKTemplate
             StatusBlock.Text = strMessage;
 
             // Collapse the StatusBlock if it has no text to conserve real estate.
-            StatusBorder.Visibility = (StatusBlock.Text != String.Empty) ? Visibility.Visible : Visibility.Collapsed;
+            StatusBorder.Visibility = String.IsNullOrEmpty(strMessage) ? Visibility.Collapsed : Visibility.Visible;
         }
 
         async void Footer_Click(object sender, RoutedEventArgs e)
@@ -110,7 +108,7 @@ namespace SDKTemplate
 
         private void Button_Click(object sender, RoutedEventArgs e)
         {
-            Splitter.IsPaneOpen = (Splitter.IsPaneOpen == true) ? false : true;
+            Splitter.IsPaneOpen = !Splitter.IsPaneOpen;
             StatusBorder.Visibility = Visibility.Collapsed;
         }
     }
@@ -125,7 +123,7 @@ namespace SDKTemplate
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             Scenario s = value as Scenario;
-            return (MainPage.Current.Scenarios.IndexOf(s) + 1) + ") " + s.Title;
+            return String.Format("{0}) {1}", MainPage.Current.Scenarios.IndexOf(s) + 1, s.Title);
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/Samples/ApplicationData/cs/Scenario1_Files.xaml.cs
+++ b/Samples/ApplicationData/cs/Scenario1_Files.xaml.cs
@@ -38,7 +38,7 @@ namespace ApplicationDataSample
 
         public Files()
         {
-            this.InitializeComponent();
+            InitializeComponent();
 
             localFolder = ApplicationData.Current.LocalFolder;
             localCacheFolder = ApplicationData.Current.LocalCacheFolder;
@@ -75,7 +75,7 @@ namespace ApplicationDataSample
         // LocalCache files are for larger files that can be recreated by the app, and for
         // machine specific or private files that should not be restored to a new device.
 
-        async void Increment_Local_Click(Object sender, RoutedEventArgs e)
+        async void Increment_Local_Click(object sender, RoutedEventArgs e)
         {
             localCounter++;
 
@@ -94,15 +94,15 @@ namespace ApplicationDataSample
 
                 LocalOutputTextBlock.Text = "Local Counter: " + text;
 
-                localCounter = int.Parse(text);
+                localCounter = Int32.Parse(text);
             }
-            catch (Exception)
+            catch
             {
                 LocalOutputTextBlock.Text = "Local Counter: <not found>";
             }
         }
 
-        async void Increment_LocalCache_Click(Object sender, RoutedEventArgs e)
+        async void Increment_LocalCache_Click(object sender, RoutedEventArgs e)
         {
             localCacheCounter++;
 
@@ -113,7 +113,7 @@ namespace ApplicationDataSample
         }
 
         async void Read_LocalCache_Counter()
-        {          
+        {
             try
             {
                 StorageFile file = await localCacheFolder.GetFileAsync(filename);
@@ -121,15 +121,15 @@ namespace ApplicationDataSample
 
                 LocalCacheOutputTextBlock.Text = "LocalCache Counter: " + text;
 
-                localCacheCounter = int.Parse(text);
+                localCacheCounter = Int32.Parse(text);
             }
-            catch (Exception)
+            catch
             {
                 LocalCacheOutputTextBlock.Text = "LocalCache Counter: <not found>";
             }
         }
 
-        async void Increment_Roaming_Click(Object sender, RoutedEventArgs e)
+        async void Increment_Roaming_Click(object sender, RoutedEventArgs e)
         {
             roamingCounter++;
 
@@ -148,15 +148,15 @@ namespace ApplicationDataSample
 
                 RoamingOutputTextBlock.Text = "Roaming Counter: " + text;
 
-                roamingCounter = int.Parse(text);
+                roamingCounter = Int32.Parse(text);
             }
-            catch (Exception)
+            catch
             {
                 RoamingOutputTextBlock.Text = "Roaming Counter: <not found>";
             }
         }
 
-        async void Increment_Temporary_Click(Object sender, RoutedEventArgs e)
+        async void Increment_Temporary_Click(object sender, RoutedEventArgs e)
         {
             temporaryCounter++;
 
@@ -175,9 +175,9 @@ namespace ApplicationDataSample
 
                 TemporaryOutputTextBlock.Text = "Temporary Counter: " + text;
 
-                temporaryCounter = int.Parse(text);
+                temporaryCounter = Int32.Parse(text);
             }
-            catch (Exception)
+            catch
             {
                 TemporaryOutputTextBlock.Text = "Temporary Counter: <not found>";
             }

--- a/Samples/ApplicationData/cs/Scenario2_Settings.xaml.cs
+++ b/Samples/ApplicationData/cs/Scenario2_Settings.xaml.cs
@@ -31,7 +31,7 @@ namespace ApplicationDataSample
 
         public Settings()
         {
-            this.InitializeComponent();
+            InitializeComponent();
 
             roamingSettings = ApplicationData.Current.RoamingSettings;
 
@@ -67,14 +67,14 @@ namespace ApplicationDataSample
         // This sample illustrates reading and writing from a roaming setting, though a
         // local setting could be used just as easily.
 
-        void WriteSetting_Click(Object sender, RoutedEventArgs e)
+        void WriteSetting_Click(object sender, RoutedEventArgs e)
         {
             roamingSettings.Values[SettingName] = "Hello World"; // example value
 
             DisplayOutput();
         }
 
-        void DeleteSetting_Click(Object sender, RoutedEventArgs e)
+        void DeleteSetting_Click(object sender, RoutedEventArgs e)
         {
             roamingSettings.Values.Remove(SettingName);
 
@@ -83,7 +83,7 @@ namespace ApplicationDataSample
 
         void DisplayOutput()
         {
-            Object value = roamingSettings.Values[SettingName];
+            object value = roamingSettings.Values[SettingName];
 
             OutputTextBlock.Text = String.Format("Setting: {0}", (value == null ? "<empty>" : ("\"" + value + "\"")));
         }

--- a/Samples/ApplicationData/cs/Scenario3_SettingContainer.xaml.cs
+++ b/Samples/ApplicationData/cs/Scenario3_SettingContainer.xaml.cs
@@ -32,28 +32,28 @@ namespace ApplicationDataSample
 
         public SettingContainer()
         {
-            this.InitializeComponent();
+            InitializeComponent();
 
             localSettings = ApplicationData.Current.LocalSettings;
 
             DisplayOutput();
         }
 
-        void CreateContainer_Click(Object sender, RoutedEventArgs e)
+        void CreateContainer_Click(object sender, RoutedEventArgs e)
         {
             ApplicationDataContainer container = localSettings.CreateContainer(containerName, ApplicationDataCreateDisposition.Always);
 
             DisplayOutput();
         }
 
-        void DeleteContainer_Click(Object sender, RoutedEventArgs e)
+        void DeleteContainer_Click(object sender, RoutedEventArgs e)
         {
             localSettings.DeleteContainer(containerName);
 
             DisplayOutput();
         }
 
-        void WriteSetting_Click(Object sender, RoutedEventArgs e)
+        void WriteSetting_Click(object sender, RoutedEventArgs e)
         {
             if (localSettings.Containers.ContainsKey(containerName))
             {
@@ -63,7 +63,7 @@ namespace ApplicationDataSample
             DisplayOutput();
         }
 
-        void DeleteSetting_Click(Object sender, RoutedEventArgs e)
+        void DeleteSetting_Click(object sender, RoutedEventArgs e)
         {
             if (localSettings.Containers.ContainsKey(containerName))
             {
@@ -78,10 +78,10 @@ namespace ApplicationDataSample
             bool hasContainer = localSettings.Containers.ContainsKey(containerName);
             bool hasSetting = hasContainer ? localSettings.Containers[containerName].Values.ContainsKey(settingName) : false;
 
-            String output = String.Format("Container Exists: {0}\n" +
+            string output = String.Format("Container Exists: {0}\n" +
                                           "Setting Exists: {1}",
-                                          hasContainer ? "true" : "false",
-                                          hasSetting ? "true" : "false");
+                                          hasContainer,
+                                          hasSetting);
 
             OutputTextBlock.Text = output;
         }

--- a/Samples/ApplicationData/cs/Scenario4_CompositeSettings.xaml.cs
+++ b/Samples/ApplicationData/cs/Scenario4_CompositeSettings.xaml.cs
@@ -33,14 +33,14 @@ namespace ApplicationDataSample
 
         public CompositeSettings()
         {
-            this.InitializeComponent();
+            InitializeComponent();
 
             roamingSettings = ApplicationData.Current.RoamingSettings;
 
             DisplayOutput();
         }
 
-        void WriteCompositeSetting_Click(Object sender, RoutedEventArgs e)
+        void WriteCompositeSetting_Click(object sender, RoutedEventArgs e)
         {
             ApplicationDataCompositeValue composite = new ApplicationDataCompositeValue();
             composite[settingName1] = 1; // example value
@@ -51,7 +51,7 @@ namespace ApplicationDataSample
             DisplayOutput();
         }
 
-        void DeleteCompositeSetting_Click(Object sender, RoutedEventArgs e)
+        void DeleteCompositeSetting_Click(object sender, RoutedEventArgs e)
         {
             roamingSettings.Values.Remove(settingName);
 

--- a/Samples/ApplicationData/cs/Scenario5_DataChangedEvent.xaml.cs
+++ b/Samples/ApplicationData/cs/Scenario5_DataChangedEvent.xaml.cs
@@ -35,7 +35,7 @@ namespace ApplicationDataSample
 
         public DataChangedEvent()
         {
-            this.InitializeComponent();
+            InitializeComponent();
 
             applicationData = ApplicationData.Current;
             roamingSettings = applicationData.RoamingSettings;
@@ -43,7 +43,7 @@ namespace ApplicationDataSample
             DisplayOutput();
         }
 
-        void SimulateRoaming_Click(Object sender, RoutedEventArgs e)
+        void SimulateRoaming_Click(object sender, RoutedEventArgs e)
         {
             roamingSettings.Values[settingName] = UserName.Text;
 
@@ -51,10 +51,10 @@ namespace ApplicationDataSample
             applicationData.SignalDataChanged();
         }
 
-        async void DataChangedHandler(Windows.Storage.ApplicationData appData, object o)
+        async void DataChangedHandler(ApplicationData appData, object o)
         {
             // DataChangeHandler may be invoked on a background thread, so use the Dispatcher to invoke the UI-related code on the UI thread.
-            await this.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
                 DisplayOutput();
             });
@@ -62,8 +62,9 @@ namespace ApplicationDataSample
 
         void DisplayOutput()
         {
-            Object value = roamingSettings.Values[settingName];
-            OutputTextBlock.Text = "Name: " + (value == null ? "<empty>" : ("\"" + value + "\"")); ;
+            object value = roamingSettings.Values[settingName];
+            OutputTextBlock.Text = "Name: " + (value == null ? "<empty>" : ("\"" + value + "\""));
+            ;
         }
 
         /// <summary>

--- a/Samples/ApplicationData/cs/Scenario6_HighPriority.xaml.cs
+++ b/Samples/ApplicationData/cs/Scenario6_HighPriority.xaml.cs
@@ -33,11 +33,11 @@ namespace ApplicationDataSample
 
         public HighPriority()
         {
-            this.InitializeComponent();
+            InitializeComponent();
 
             applicationData = ApplicationData.Current;
             roamingSettings = applicationData.RoamingSettings;
-            
+
             DisplayOutput(false);
         }
 
@@ -58,7 +58,7 @@ namespace ApplicationDataSample
         // a significant change to the data it represents.  Examples could include changing
         // music tracks, turning the page in a book, or finishing a level in a game.
 
-        void IncrementHighPriority_Click(Object sender, RoutedEventArgs e)
+        void IncrementHighPriority_Click(object sender, RoutedEventArgs e)
         {
             int counter = Convert.ToInt32(roamingSettings.Values["HighPriority"]);
 
@@ -67,10 +67,10 @@ namespace ApplicationDataSample
             DisplayOutput(false);
         }
 
-        async void DataChangedHandler(Windows.Storage.ApplicationData appData, object o)
+        async void DataChangedHandler(ApplicationData appData, object o)
         {
             // DataChangeHandler may be invoked on a background thread, so use the Dispatcher to invoke the UI-related code on the UI thread.
-            await this.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
                 DisplayOutput(true);
             });

--- a/Samples/ApplicationData/cs/Scenario7_Msappdata.xaml.cs
+++ b/Samples/ApplicationData/cs/Scenario7_Msappdata.xaml.cs
@@ -28,7 +28,7 @@ namespace ApplicationDataSample
 
         public Msappdata()
         {
-            this.InitializeComponent();
+            InitializeComponent();
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace ApplicationDataSample
                 StorageFile sourceFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///assets/appDataLocal.png"));
                 await sourceFile.CopyAsync(appData.LocalFolder);
             }
-            catch (Exception)
+            catch
             {
                 // If the image has already been copied the CopyAsync() method above will fail.
                 // Ignore this error.
@@ -56,7 +56,7 @@ namespace ApplicationDataSample
                 StorageFile sourceFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///assets/appDataRoaming.png"));
                 await sourceFile.CopyAsync(appData.RoamingFolder);
             }
-            catch (Exception)
+            catch
             {
                 // If the image has already been copied the CopyAsync() method above will fail.
                 // Ignore this error.
@@ -67,7 +67,7 @@ namespace ApplicationDataSample
                 StorageFile sourceFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///assets/appDataTemp.png"));
                 await sourceFile.CopyAsync(appData.TemporaryFolder);
             }
-            catch (Exception)
+            catch
             {
                 // If the image has already been copied the CopyAsync() method above will fail.
                 // Ignore this error.

--- a/Samples/ApplicationData/cs/Scenario8_ClearScenario.xaml.cs
+++ b/Samples/ApplicationData/cs/Scenario8_ClearScenario.xaml.cs
@@ -28,17 +28,17 @@ namespace ApplicationDataSample
 
         public ClearScenario()
         {
-            this.InitializeComponent();
+            InitializeComponent();
         }
 
-        async void Clear_Click(Object sender, RoutedEventArgs e)
+        async void Clear_Click(object sender, RoutedEventArgs e)
         {
             try
             {
-                await Windows.Storage.ApplicationData.Current.ClearAsync();
+                await ApplicationData.Current.ClearAsync();
                 OutputTextBlock.Text = "ApplicationData has been cleared.  Visit the other scenarios to see that their data has been cleared.";
             }
-            catch (Exception)
+            catch
             {
                 OutputTextBlock.Text = "Unable to clear settings. This can happen when files are in use.";
             }

--- a/Samples/ApplicationData/cs/Scenario9_SetVersion.xaml.cs
+++ b/Samples/ApplicationData/cs/Scenario9_SetVersion.xaml.cs
@@ -34,7 +34,7 @@ namespace ApplicationDataSample
 
         public SetVersion()
         {
-            this.InitializeComponent();
+            InitializeComponent();
 
             appData = ApplicationData.Current;
 
@@ -95,15 +95,15 @@ namespace ApplicationDataSample
             deferral.Complete();
         }
 
-        async void SetVersion0_Click(Object sender, RoutedEventArgs e)
+        async void SetVersion0_Click(object sender, RoutedEventArgs e)
         {
-            await appData.SetVersionAsync(0, new ApplicationDataSetVersionHandler(SetVersionHandler0));
+            await appData.SetVersionAsync(0, SetVersionHandler0);
             DisplayOutput();
         }
 
-        async void SetVersion1_Click(Object sender, RoutedEventArgs e)
+        async void SetVersion1_Click(object sender, RoutedEventArgs e)
         {
-            await appData.SetVersionAsync(1, new ApplicationDataSetVersionHandler(SetVersionHandler1));
+            await appData.SetVersionAsync(1, SetVersionHandler1);
             DisplayOutput();
         }
 

--- a/Samples/ApplicationData/cs/SuspensionManager.cs
+++ b/Samples/ApplicationData/cs/SuspensionManager.cs
@@ -35,7 +35,10 @@ namespace SDKTemplate.Common
         /// </summary>
         public static Dictionary<string, object> SessionState
         {
-            get { return _sessionState; }
+            get
+            {
+                return _sessionState;
+            }
         }
 
         /// <summary>
@@ -45,7 +48,10 @@ namespace SDKTemplate.Common
         /// </summary>
         public static List<Type> KnownTypes
         {
-            get { return _knownTypes; }
+            get
+            {
+                return _knownTypes;
+            }
         }
 
         /// <summary>
@@ -100,9 +106,9 @@ namespace SDKTemplate.Common
         /// <returns>An asynchronous task that reflects when session state has been read.  The
         /// content of <see cref="SessionState"/> should not be relied upon until this task
         /// completes.</returns>
-        public static async Task RestoreAsync(String sessionBaseKey = null)
+        public static async Task RestoreAsync(string sessionBaseKey = null)
         {
-            _sessionState = new Dictionary<String, Object>();
+            _sessionState = new Dictionary<string, object>();
 
             try
             {
@@ -133,11 +139,11 @@ namespace SDKTemplate.Common
         }
 
         private static DependencyProperty FrameSessionStateKeyProperty =
-            DependencyProperty.RegisterAttached("_FrameSessionStateKey", typeof(String), typeof(SuspensionManager), null);
+            DependencyProperty.RegisterAttached("_FrameSessionStateKey", typeof(string), typeof(SuspensionManager), null);
         private static DependencyProperty FrameSessionBaseKeyProperty =
-            DependencyProperty.RegisterAttached("_FrameSessionBaseKeyParams", typeof(String), typeof(SuspensionManager), null);
+            DependencyProperty.RegisterAttached("_FrameSessionBaseKeyParams", typeof(string), typeof(SuspensionManager), null);
         private static DependencyProperty FrameSessionStateProperty =
-            DependencyProperty.RegisterAttached("_FrameSessionState", typeof(Dictionary<String, Object>), typeof(SuspensionManager), null);
+            DependencyProperty.RegisterAttached("_FrameSessionState", typeof(Dictionary<string, object>), typeof(SuspensionManager), null);
         private static List<WeakReference<Frame>> _registeredFrames = new List<WeakReference<Frame>>();
 
         /// <summary>
@@ -154,7 +160,7 @@ namespace SDKTemplate.Common
         /// store navigation-related information.</param>
         /// <param name="sessionBaseKey">An optional key that identifies the type of session.
         /// This can be used to distinguish between multiple application launch scenarios.</param>
-        public static void RegisterFrame(Frame frame, String sessionStateKey, String sessionBaseKey = null)
+        public static void RegisterFrame(Frame frame, string sessionStateKey, string sessionBaseKey = null)
         {
             if (frame.GetValue(FrameSessionStateKeyProperty) != null)
             {
@@ -166,7 +172,7 @@ namespace SDKTemplate.Common
                 throw new InvalidOperationException("Frames must be either be registered before accessing frame session state, or not registered at all");
             }
 
-            if (!string.IsNullOrEmpty(sessionBaseKey))
+            if (!String.IsNullOrEmpty(sessionBaseKey))
             {
                 frame.SetValue(FrameSessionBaseKeyProperty, sessionBaseKey);
                 sessionStateKey = sessionBaseKey + "_" + sessionStateKey;
@@ -192,7 +198,7 @@ namespace SDKTemplate.Common
         {
             // Remove session state and remove the frame from the list of frames whose navigation
             // state will be saved (along with any weak references that are no longer reachable)
-            SessionState.Remove((String)frame.GetValue(FrameSessionStateKeyProperty));
+            SessionState.Remove((string)frame.GetValue(FrameSessionStateKeyProperty));
             _registeredFrames.RemoveAll((weakFrameReference) =>
             {
                 Frame testFrame;
@@ -213,29 +219,30 @@ namespace SDKTemplate.Common
         /// <param name="frame">The instance for which session state is desired.</param>
         /// <returns>A collection of state subject to the same serialization mechanism as
         /// <see cref="SessionState"/>.</returns>
-        public static Dictionary<String, Object> SessionStateForFrame(Frame frame)
+        public static Dictionary<string, object> SessionStateForFrame(Frame frame)
         {
-            var frameState = (Dictionary<String, Object>)frame.GetValue(FrameSessionStateProperty);
+            var frameState = (Dictionary<string, object>)frame.GetValue(FrameSessionStateProperty);
 
             if (frameState == null)
             {
-                var frameSessionKey = (String)frame.GetValue(FrameSessionStateKeyProperty);
-                if (frameSessionKey != null)
+                var frameSessionKey = (string)frame.GetValue(FrameSessionStateKeyProperty);
+                if (frameSessionKey == null)
+                {
+                    // Frames that aren't registered have transient state
+                    frameState = new Dictionary<string, object>();
+                }
+                else
                 {
                     // Registered frames reflect the corresponding session state
                     if (!_sessionState.ContainsKey(frameSessionKey))
                     {
-                        _sessionState[frameSessionKey] = new Dictionary<String, Object>();
+                        _sessionState[frameSessionKey] = new Dictionary<string, object>();
                     }
-                    frameState = (Dictionary<String, Object>)_sessionState[frameSessionKey];
-                }
-                else
-                {
-                    // Frames that aren't registered have transient state
-                    frameState = new Dictionary<String, Object>();
+                    frameState = (Dictionary<string, object>)_sessionState[frameSessionKey];
                 }
                 frame.SetValue(FrameSessionStateProperty, frameState);
             }
+
             return frameState;
         }
 
@@ -244,7 +251,7 @@ namespace SDKTemplate.Common
             var frameState = SessionStateForFrame(frame);
             if (frameState.ContainsKey("Navigation"))
             {
-                frame.SetNavigationState((String)frameState["Navigation"]);
+                frame.SetNavigationState((string)frameState["Navigation"]);
             }
         }
 


### PR DESCRIPTION
I applied the followings:
- When using a built-in type itself I used its C# alias but when using its static method I used its class name, eg. string output = String.Format(...);
- Removed unnecessary "this" qualifications.
- Removed unnecessary namespace qualifications.
- Removed unnecessarily specified Exception type from catch blocks
- Simplified some boolean expressions.
- Reduced nesting code
