### PR TITLE
Change the device family from .mobile to .Universal to allow running …

### DIFF
--- a/Samples/FolderEnumeration/cs/Package.appxmanifest
+++ b/Samples/FolderEnumeration/cs/Package.appxmanifest
@@ -21,7 +21,7 @@
     </Properties>
 
     <Dependencies>
-        <TargetDeviceFamily Name="Windows.Mobile" MinVersion="10.0.10240.0" MaxVersionTested="10.0.10240.0" />
+        <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.10240.0" MaxVersionTested="10.0.10240.0" />
     </Dependencies>
 
     <Resources>


### PR DESCRIPTION
…on local machine, and to avoid dev's getting confused from deploy error messages...els
This is just a small thing, but since the samples are all supposed to be UWP, they should all specify the universal device family.
If we don't a very cryptic error message is issued by visual studio, and the advice for fixing it is poor.

"2>Error : DEP0700 : Registration of the app failed. Deployment Register operation with target volume C: on Package Microsoft.SDKSamples.FolderEnumeration.CS_1.0.0.0_x86__8wekyb3d8bbwe from:  (AppxManifest.xml)  failed with error 0x80073CFD. See http://go.microsoft.com/fwlink/?LinkId=235160 for help diagnosing app deployment issues. (0x80073cfd)"

We should likely check the other appxmanifest files as well, as others may have slipped through.

-thanks
-e