### PR TITLE
Storage trigger

### DIFF
--- a/Samples/BackgroundTask/cs/BackgroundTask/BackgroundTask.csproj
+++ b/Samples/BackgroundTask/cs/BackgroundTask/BackgroundTask.csproj
@@ -103,9 +103,7 @@
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="SampleConfiguration.cs" />
-    <Compile Include="Scenario1_SampleBackgroundTask.xaml.cs">
-      <DependentUpon>Scenario1_SampleBackgroundTask.xaml</DependentUpon>
-    </Compile>
+    <Compile Include="Scenario1_SampleBackgroundTask.xaml.cs" />
     <Compile Include="Scenario2_SampleBackgroundTaskWithCondition.xaml.cs">
       <DependentUpon>Scenario2_SampleBackgroundTaskWithCondition.xaml</DependentUpon>
     </Compile>
@@ -117,6 +115,9 @@
     </Compile>
     <Compile Include="Scenario3_ServicingCompleteTask.xaml.cs">
       <DependentUpon>Scenario3_ServicingCompleteTask.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Scenario6_StorageChangeTriggerTask.xaml.cs">
+      <DependentUpon>Scenario6_StorageChangeTriggerTask.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -134,12 +135,6 @@
       <Link>MainPage.xaml</Link>
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
-    </Page>
-    <Page Include="..\..\shared\Scenario1_SampleBackgroundTask.xaml">
-      <Link>Scenario1_SampleBackgroundTask.xaml</Link>
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>
-      </SubType>
     </Page>
     <Page Include="..\..\shared\Scenario2_SampleBackgroundTaskWithCondition.xaml">
       <Link>Scenario2_SampleBackgroundTaskWithCondition.xaml</Link>
@@ -168,6 +163,15 @@
       <Link>Styles\Styles.xaml</Link>
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Scenario1_SampleBackgroundTask.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="..\..\shared\Scenario6_StorageChangeTriggerTask.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+      <Link>Scenario6_StorageChangeTriggerTask.xaml</Link>
     </Page>
   </ItemGroup>
   <ItemGroup>

--- a/Samples/BackgroundTask/cs/BackgroundTask/Package.appxmanifest
+++ b/Samples/BackgroundTask/cs/BackgroundTask/Package.appxmanifest
@@ -1,70 +1,53 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<Package
-  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
-  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
-  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  IgnorableNamespaces="uap mp">
-
-    <Identity
-      Name="Microsoft.SDKSamples.BackgroundTask.CS"
-      Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
-      Version="1.0.0.0" />
-
-
-    <mp:PhoneIdentity PhoneProductId="6bfc8704-eb93-47af-bb92-746b55f3103d" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
-
-    <Properties>
-        <DisplayName>Background Tasks C# Sample</DisplayName>
-        <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
-        <Logo>Assets\StoreLogo-sdk.png</Logo>
-    </Properties>
-
-    <Dependencies>
-        <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.10240.0" MaxVersionTested="10.0.10240.0" />
-    </Dependencies>
-
-    <Resources>
-        <Resource Language="x-generate"/>
-    </Resources>
-
-    <Applications>
-        <Application Id="App"
-          Executable="$targetnametoken$.exe"
-          EntryPoint="BackgroundTask.App">
-            <uap:VisualElements
-              DisplayName="Background Tasks C# Sample"
-              Square150x150Logo="Assets\SquareTile-sdk.png"
-              Square44x44Logo="Assets\SmallTile-sdk.png"
-              Description="Background Tasks C# Sample"
-              BackgroundColor="#00b2f0">
-              <uap:LockScreen Notification="badgeAndTileText" BadgeLogo="Assets\smalltile-Windows-sdk.png" />
-                <uap:SplashScreen Image="Assets\Splash-sdk.png" />
-                <uap:DefaultTile Wide310x150Logo="Assets\tile-sdk.png" >
-                    <uap:ShowNameOnTiles>
-                        <uap:ShowOn Tile="square150x150Logo" />
-                        <uap:ShowOn Tile="wide310x150Logo" />
-                    </uap:ShowNameOnTiles>
-                </uap:DefaultTile>
-            </uap:VisualElements>
-
-          <Extensions>
-            <Extension Category="windows.backgroundTasks" EntryPoint="Tasks.SampleBackgroundTask">
-              <BackgroundTasks>
-                <Task Type="systemEvent" />
-                <Task Type="timer" />
-              </BackgroundTasks>
-            </Extension>
-            <Extension Category="windows.backgroundTasks" EntryPoint="Tasks.ServicingComplete">
-              <BackgroundTasks>
-                <Task Type="systemEvent"/>
-              </BackgroundTasks>
-            </Extension>
-          </Extensions>
-        </Application>
-    </Applications>
-
-    <Capabilities>
-        <Capability Name="internetClient" />
-    </Capabilities>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+  <Identity Name="Microsoft.SDKSamples.BackgroundTask.CS" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.0.0.0" />
+  <mp:PhoneIdentity PhoneProductId="6bfc8704-eb93-47af-bb92-746b55f3103d" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
+  <Properties>
+    <DisplayName>Background Tasks C# Sample</DisplayName>
+    <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
+    <Logo>Assets\StoreLogo-sdk.png</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.10240.0" MaxVersionTested="10.0.10240.0" />
+  </Dependencies>
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+  <Applications>
+    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="BackgroundTask.App">
+      <uap:VisualElements DisplayName="Background Tasks C# Sample" Square150x150Logo="Assets\SquareTile-sdk.png" Square44x44Logo="Assets\SmallTile-sdk.png" Description="Background Tasks C# Sample" BackgroundColor="#00b2f0">
+        <uap:LockScreen Notification="badgeAndTileText" BadgeLogo="Assets\smalltile-Windows-sdk.png" />
+        <uap:SplashScreen Image="Assets\Splash-sdk.png" />
+        <uap:DefaultTile Wide310x150Logo="Assets\tile-sdk.png">
+          <uap:ShowNameOnTiles>
+            <uap:ShowOn Tile="square150x150Logo" />
+            <uap:ShowOn Tile="wide310x150Logo" />
+          </uap:ShowNameOnTiles>
+        </uap:DefaultTile>
+      </uap:VisualElements>
+      <Extensions>
+        <Extension Category="windows.backgroundTasks" EntryPoint="Tasks.StorageChangeBackgroundTask">
+          <BackgroundTasks>
+            <Task Type="general" />
+          </BackgroundTasks>
+        </Extension>
+        <Extension Category="windows.backgroundTasks" EntryPoint="Tasks.ServicingComplete">
+          <BackgroundTasks>
+            <Task Type="systemEvent" />
+          </BackgroundTasks>
+        </Extension>
+        <Extension Category="windows.backgroundTasks" EntryPoint="Tasks.SampleBackgroundTask">
+          <BackgroundTasks>
+            <Task Type="systemEvent" />
+            <Task Type="timer" />
+          </BackgroundTasks>
+        </Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+  <Capabilities>
+    <Capability Name="internetClient" />
+    <uap:Capability Name="picturesLibrary" />
+    <uap:Capability Name="videosLibrary" />
+  </Capabilities>
 </Package>

--- a/Samples/BackgroundTask/cs/BackgroundTask/SampleConfiguration.cs
+++ b/Samples/BackgroundTask/cs/BackgroundTask/SampleConfiguration.cs
@@ -28,7 +28,8 @@ namespace SDKTemplate
             new Scenario() { Title="Background Task with Condition", ClassType=typeof(SampleBackgroundTaskWithCondition)},
             new Scenario() { Title="Servicing Complete Task", ClassType=typeof(ServicingCompleteTask)},
             new Scenario() { Title="Background Task with Time Trigger", ClassType=typeof(TimeTriggeredTask) },
-            new Scenario() { Title="Background Task with Application Trigger", ClassType=typeof(ApplicationTriggerTask) }
+            new Scenario() { Title="Background Task with Application Trigger", ClassType=typeof(ApplicationTriggerTask) },
+            new Scenario() { Title="Storage Changed Trigger Task", ClassType=typeof(StorageChangeTriggerTask) }
         };
     }
 
@@ -65,6 +66,12 @@ namespace SDKTemplate
         public static string ApplicationTriggerTaskProgress = "";
         public static string ApplicationTriggerTaskResult = "";
         public static bool ApplicationTriggerTaskRegistered = false;
+
+        public const string StorageChangeTriggerTaskName = "StorageChangeTriggerTask";
+        public const string StorageChangeTriggerTaskEntryPoint = "Tasks.StorageChangeBackgroundTask";
+        public static string StorageChangeTriggerTaskProgress = "";
+        public static string StorageChangeTriggerTaskResult = "";
+        public static bool StorageChangeTriggerTaskRegistered = false;
 
         /// <summary>
         /// Register a background task with the specified taskEntryPoint, name, trigger,

--- a/Samples/BackgroundTask/cs/BackgroundTask/SampleConfiguration.cs
+++ b/Samples/BackgroundTask/cs/BackgroundTask/SampleConfiguration.cs
@@ -83,9 +83,10 @@ namespace SDKTemplate
         /// <param name="condition">An optional conditional event that must be true for the task to fire.</param>
         public static async Task<BackgroundTaskRegistration> RegisterBackgroundTask(String taskEntryPoint, String name, IBackgroundTrigger trigger, IBackgroundCondition condition)
         {
+            BackgroundAccessStatus bg_status;
             if (TaskRequiresBackgroundAccess(name))
             {
-                await BackgroundExecutionManager.RequestAccessAsync();
+                bg_status = await BackgroundExecutionManager.RequestAccessAsync();
             }
 
             var builder = new BackgroundTaskBuilder();
@@ -105,6 +106,10 @@ namespace SDKTemplate
                 builder.CancelOnConditionLoss = true;
             }
 
+            // Exceptions for Windows 10 UWP
+            // Trigger was not set: Value does not fall within the expected range.
+            // Trigger is set to a StorageLibraryContentChangedTrigger on Windows: Element not found
+            // Task was not properly registered in the manifest: Not Registered
             BackgroundTaskRegistration task = builder.Register();
 
             UpdateBackgroundTaskStatus(name, true);

--- a/Samples/BackgroundTask/cs/BackgroundTask/SampleConfiguration.cs
+++ b/Samples/BackgroundTask/cs/BackgroundTask/SampleConfiguration.cs
@@ -125,8 +125,7 @@ namespace SDKTemplate
         public static void UnregisterBackgroundTasks(String name)
         {
             //
-            // Loop through all background tasks and unregister any with SampleBackgroundTaskName or
-            // SampleBackgroundTaskWithConditionName.
+            // Loop through all background tasks and unregister any with the name the caller passes
             //
             foreach (var cur in BackgroundTaskRegistration.AllTasks)
             {
@@ -162,6 +161,9 @@ namespace SDKTemplate
                     break;
                 case ApplicationTriggerTaskName:
                     ApplicationTriggerTaskRegistered = registered;
+                    break;
+                case StorageChangeTriggerTaskName:
+                    StorageChangeTriggerTaskRegistered = registered;
                     break;
             }
         }
@@ -211,7 +213,8 @@ namespace SDKTemplate
         public static bool TaskRequiresBackgroundAccess(String name)
         {
             if ((name == TimeTriggeredTaskName) ||
-                (name == ApplicationTriggerTaskName))
+                (name == ApplicationTriggerTaskName) ||
+                (name == StorageChangeTriggerTaskName))
             {
                 return true;
             }

--- a/Samples/BackgroundTask/cs/BackgroundTask/Scenario6_StorageChangeTriggerTask.xaml.cs
+++ b/Samples/BackgroundTask/cs/BackgroundTask/Scenario6_StorageChangeTriggerTask.xaml.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Windows.ApplicationModel.Background;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using Windows.Storage;
+using Windows.UI.Core;
+
+// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace SDKTemplate
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class StorageChangeTriggerTask : Page
+    {
+        private MainPage rootPage = MainPage.Current;
+
+        public StorageChangeTriggerTask()
+        {
+            this.InitializeComponent();
+        }
+        /// <summary>
+        /// Invoked when this page is about to be displayed in a Frame.
+        /// </summary>
+        /// <param name="e">Event data that describes how this page was reached.  The Parameter
+        /// property is typically used to configure the page.</param>
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            foreach (var task in BackgroundTaskRegistration.AllTasks)
+            {
+                if (task.Value.Name == BackgroundTaskSample.StorageChangeTriggerTaskName)
+                {
+                    AttachProgressAndCompletedHandlers(task.Value);
+                    BackgroundTaskSample.UpdateBackgroundTaskStatus(BackgroundTaskSample.StorageChangeTriggerTaskName, true);
+                    break;
+                }
+            }
+
+            UpdateUI();
+        }
+
+        /// <summary>
+        /// Register a SampleBackgroundTask.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private async void RegisterBackgroundTask(object sender, RoutedEventArgs e)
+        {
+            StorageLibrary lib = await StorageLibrary.GetLibraryAsync(KnownLibraryId.Pictures);
+            StorageLibraryContentChangedTrigger libraryTrigger = StorageLibraryContentChangedTrigger.Create(lib);
+
+            var task = BackgroundTaskSample.RegisterBackgroundTask(BackgroundTaskSample.StorageChangeTriggerTaskEntryPoint,
+                                                                   BackgroundTaskSample.StorageChangeTriggerTaskName,
+#if true
+                                                                   libraryTrigger,
+#else
+                                                                   new SystemTrigger(SystemTriggerType.TimeZoneChange, false),
+#endif
+                                                                   null);
+            await task;
+            AttachProgressAndCompletedHandlers(task.Result);
+            UpdateUI();
+        }
+
+        /// <summary>
+        /// Unregister a SampleBackgroundTask.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void UnregisterBackgroundTask(object sender, RoutedEventArgs e)
+        {
+            BackgroundTaskSample.UnregisterBackgroundTasks(BackgroundTaskSample.StorageChangeTriggerTaskName);
+            UpdateUI();
+        }
+
+        /// <summary>
+        /// Attach progress and completed handers to a background task.
+        /// </summary>
+        /// <param name="task">The task to attach progress and completed handlers to.</param>
+        private void AttachProgressAndCompletedHandlers(IBackgroundTaskRegistration task)
+        {
+            task.Progress += new BackgroundTaskProgressEventHandler(OnProgress);
+            task.Completed += new BackgroundTaskCompletedEventHandler(OnCompleted);
+        }
+
+        /// <summary>
+        /// Handle background task progress.
+        /// </summary>
+        /// <param name="task">The task that is reporting progress.</param>
+        /// <param name="e">Arguments of the progress report.</param>
+        private void OnProgress(IBackgroundTaskRegistration task, BackgroundTaskProgressEventArgs args)
+        {
+            var progress = "Progress: " + args.Progress + "%";
+            BackgroundTaskSample.StorageChangeTriggerTaskProgress = progress;
+            UpdateUI();
+        }
+
+        /// <summary>
+        /// Handle background task completion.
+        /// </summary>
+        /// <param name="task">The task that is reporting completion.</param>
+        /// <param name="e">Arguments of the completion report.</param>
+        private void OnCompleted(IBackgroundTaskRegistration task, BackgroundTaskCompletedEventArgs args)
+        {
+            UpdateUI();
+        }
+
+        /// <summary>
+        /// Update the scenario UI.
+        /// </summary>
+        private async void UpdateUI()
+        {
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
+            () =>
+            {
+                RegisterButton.IsEnabled = !BackgroundTaskSample.StorageChangeTriggerTaskRegistered;
+                UnregisterButton.IsEnabled = BackgroundTaskSample.StorageChangeTriggerTaskRegistered;
+                Progress.Text = BackgroundTaskSample.StorageChangeTriggerTaskProgress;
+                Status.Text = BackgroundTaskSample.GetBackgroundTaskStatus(BackgroundTaskSample.StorageChangeTriggerTaskName);
+            });
+        }
+    }
+}

--- a/Samples/BackgroundTask/cs/Tasks/StorageChangeBackgroundTask.cs
+++ b/Samples/BackgroundTask/cs/Tasks/StorageChangeBackgroundTask.cs
@@ -1,0 +1,170 @@
+﻿//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.Background;
+using Windows.Foundation;
+using Windows.Storage;
+using Windows.Storage.Search;
+using Windows.System.Threading;
+
+//
+// The namespace for the background tasks.
+//
+namespace Tasks
+{
+    //
+    // A background task always implements the IBackgroundTask interface.
+    //
+    public sealed class StorageChangeBackgroundTask : IBackgroundTask
+    {
+        BackgroundTaskCancellationReason _cancelReason = BackgroundTaskCancellationReason.Abort;
+        volatile bool _cancelRequested = false;
+        BackgroundTaskDeferral _deferral = null;
+        ThreadPoolTimer _periodicTimer = null;
+        uint _progress = 0;
+        IBackgroundTaskInstance _taskInstance = null;
+
+        //
+        // The Run method is the entry point of a background task.
+        //
+        public void Run(IBackgroundTaskInstance taskInstance)
+        {
+            Debug.WriteLine("Background " + taskInstance.Task.Name + " Starting...");
+
+            //
+            // Query BackgroundWorkCost
+            // Guidance: If BackgroundWorkCost is high, then perform only the minimum amount
+            // of work in the background task and return immediately.
+            //
+            var cost = BackgroundWorkCost.CurrentBackgroundWorkCost;
+            var settings = ApplicationData.Current.LocalSettings;
+            settings.Values["BackgroundWorkCost"] = cost.ToString();
+
+            //
+            // Associate a cancellation handler with the background task.
+            //
+            taskInstance.Canceled += new BackgroundTaskCanceledEventHandler(OnCanceled);
+
+            //
+            // Get the deferral object from the task instance, and take a reference to the taskInstance;
+            //
+            _deferral = taskInstance.GetDeferral();
+            _taskInstance = taskInstance;
+
+            _periodicTimer = ThreadPoolTimer.CreatePeriodicTimer(new TimerElapsedHandler(PeriodicTimerCallback), TimeSpan.FromSeconds(1));
+
+//            await ScanLibraryFilesAsync();
+        }
+
+        //
+        // Handles background task cancellation.
+        //
+        private void OnCanceled(IBackgroundTaskInstance sender, BackgroundTaskCancellationReason reason)
+        {
+            //
+            // Indicate that the background task is canceled.
+            //
+            _cancelRequested = true;
+            _cancelReason = reason;
+
+            Debug.WriteLine("Background " + sender.Task.Name + " Cancel Requested...");
+        }
+
+        //
+        // Simulate the background task activity.
+        //
+        private void PeriodicTimerCallback(ThreadPoolTimer timer)
+        {
+            if ((_cancelRequested == false) && (_progress < 100))
+            {
+                _progress += 10;
+                _taskInstance.Progress = _progress;
+            }
+            else
+            {
+                _periodicTimer.Cancel();
+
+                var settings = ApplicationData.Current.LocalSettings;
+                var key = _taskInstance.Task.Name;
+
+                //
+                // Write to LocalSettings to indicate that this background task ran.
+                //
+                settings.Values[key] = (_progress < 100) ? "Canceled with reason: " + _cancelReason.ToString() : "Completed";
+                Debug.WriteLine("Background " + _taskInstance.Task.Name + settings.Values[key]);
+
+                //
+                // Indicate that the background task has completed.
+                //
+                _deferral.Complete();
+            }
+        }
+
+        private async Task ScanLibraryFilesAsync()
+        {
+            var appSettings = ApplicationData.Current.LocalSettings;
+            if (!appSettings.Values.ContainsKey("LastSearchTime"))
+            {
+                //We haven't done a first run crawl, so lets just bail out
+                return;
+            }
+            DateTimeOffset lastSearchTime = (DateTimeOffset)appSettings.Values["LastSearchTime"];
+
+            var supportedExtensions = new List<String>()
+            {
+                ".bmp",
+                ".jpg",
+                ".tif",
+                ".png"
+            };
+
+            StorageFolder photos = KnownFolders.PicturesLibrary;
+            QueryOptions option = new QueryOptions(CommonFileQuery.OrderByDate,
+                                                    supportedExtensions);
+            //This is important because we are going to use indexer only properties for the query
+            //later
+            option.IndexerOption = IndexerOption.OnlyUseIndexer;
+            option.FolderDepth = FolderDepth.Shallow;
+            //Set the filter to things that have changed since the lastSearchTime. Note that the 
+            //time must be formatted as Zulu time as shown here.
+            string timeFilter = "System.Search.GatherTime:>=" +
+                              lastSearchTime.ToString("yyyy\\-MM\\-dd\\THH\\:mm\\:ss\\Z");
+            option.ApplicationSearchFilter += timeFilter;
+
+
+            StorageFileQueryResult resultSet = photos.CreateFileQueryWithOptions(option);
+            lastSearchTime = DateTimeOffset.UtcNow;
+
+            uint currentIndex = 0;
+            const uint stepSize = 10;
+            IReadOnlyList<StorageFile> files = await resultSet.GetFilesAsync(currentIndex,
+                stepSize);
+            currentIndex += stepSize;
+
+            for (; files.Count != 0; files =
+                await resultSet.GetFilesAsync(currentIndex, stepSize),
+                currentIndex += stepSize)
+            {
+                foreach (StorageFile file in files)
+                {
+                    //Note we are assuming that the database will handle any concurrency issues
+                    // do something(file);
+                }
+            }
+            //Update the last time that we searched for files
+            appSettings.Values["LastSearchTime"] = DateTimeOffset.UtcNow;
+        }
+    }
+}

--- a/Samples/BackgroundTask/cs/Tasks/Tasks.csproj
+++ b/Samples/BackgroundTask/cs/Tasks/Tasks.csproj
@@ -103,6 +103,7 @@
     <Compile Include="SampleBackgroundTask.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServicingComplete.cs" />
+    <Compile Include="StorageChangeBackgroundTask.cs" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/Samples/BackgroundTask/shared/Scenario6_StorageChangeTriggerTask.xaml
+++ b/Samples/BackgroundTask/shared/Scenario6_StorageChangeTriggerTask.xaml
@@ -1,0 +1,31 @@
+﻿<Page
+    x:Class="SDKTemplate.StorageChangeTriggerTask"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:SDKTemplate"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid x:Name="RootGrid" Margin="12,20,12,12">
+            <ScrollViewer VerticalScrollMode="Auto" VerticalScrollBarVisibility="Auto">
+                <StackPanel>
+                    <TextBlock Text="Description:" Style="{StaticResource SampleHeaderTextStyle}"/>
+                    <TextBlock Style="{StaticResource ScenarioDescriptionTextStyle}" TextWrapping="Wrap">
+                        Registers a background task for changes in the picture library.  The background task
+                        runs whenever the library is changed in any way.
+                    </TextBlock>
+                    <StackPanel HorizontalAlignment="Left" VerticalAlignment="Top" Orientation="Horizontal" Margin="0,10,0,10">
+                        <Button x:Name="RegisterButton" Content="Register" Click="RegisterBackgroundTask" Margin="0,0,10,0"/>
+                        <Button x:Name="UnregisterButton" Content="Unregister" Click="UnregisterBackgroundTask"/>
+                    </StackPanel>
+                    <StackPanel>
+                        <TextBlock x:Name="Status" Style="{StaticResource BasicTextStyle}" TextWrapping="Wrap" Text="Unregistered"/>
+                        <TextBlock x:Name="Progress" Style="{StaticResource BasicTextStyle}" TextWrapping="Wrap" Text=""/>
+                    </StackPanel>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+    </Grid>
+</Page>

--- a/Samples/BackgroundTask/shared/Scenario6_StorageChangeTriggerTask.xaml
+++ b/Samples/BackgroundTask/shared/Scenario6_StorageChangeTriggerTask.xaml
@@ -15,6 +15,12 @@
                     <TextBlock Style="{StaticResource ScenarioDescriptionTextStyle}" TextWrapping="Wrap">
                         Registers a background task for changes in the picture library.  The background task
                         runs whenever the library is changed in any way.
+                        <LineBreak></LineBreak>
+                        To test, just register the background task, then take a picture.  The background task
+                        will scan the pictures library and report the number of items in the library.
+                        (the camera roll is stored beneath the pictures library) 
+                        <LineBreak></LineBreak>
+                        The register button will throw an "element not found" exception on Windows.
                     </TextBlock>
                     <StackPanel HorizontalAlignment="Left" VerticalAlignment="Top" Orientation="Horizontal" Margin="0,10,0,10">
                         <Button x:Name="RegisterButton" Content="Register" Click="RegisterBackgroundTask" Margin="0,0,10,0"/>

--- a/Samples/FileSearch/cs/FileSearch.sln
+++ b/Samples/FileSearch/cs/FileSearch.sln
@@ -1,43 +1,40 @@
 ﻿
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22609.0
+VisualStudioVersion = 14.0.24627.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileSearch", "FileSearch.csproj", "{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}"
 EndProject
 Global
-    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-        Debug|ARM = Debug|ARM
-        Debug|x64 = Debug|x64
-        Debug|x86 = Debug|x86
-        Release|ARM = Release|ARM
-        Release|x64 = Release|x64
-        Release|x86 = Release|x86
-    EndGlobalSection
-    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|ARM.ActiveCfg = Debug|ARM
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|ARM.Build.0 = Debug|ARM
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|ARM.Deploy.0 = Debug|ARM
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|x64.ActiveCfg = Debug|x64
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|x64.Build.0 = Debug|x64
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|x64.Deploy.0 = Debug|x64
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|x86.ActiveCfg = Debug|x86
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|x86.Build.0 = Debug|x86
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|x86.Deploy.0 = Debug|x86
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|ARM.ActiveCfg = Release|ARM
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|ARM.Build.0 = Release|ARM
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|ARM.Deploy.0 = Release|ARM
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|x64.ActiveCfg = Release|x64
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|x64.Build.0 = Release|x64
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|x64.Deploy.0 = Release|x64
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|x86.ActiveCfg = Release|x86
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|x86.Build.0 = Release|x86
-        {CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|x86.Deploy.0 = Release|x86
-    EndGlobalSection
-    GlobalSection(SolutionProperties) = preSolution
-        HideSolutionNode = FALSE
-    EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM = Debug|ARM
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|ARM = Release|ARM
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|ARM.ActiveCfg = Debug|ARM
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|ARM.Build.0 = Debug|ARM
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|ARM.Deploy.0 = Debug|ARM
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|x64.ActiveCfg = Debug|x64
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|x64.Build.0 = Debug|x64
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|x64.Deploy.0 = Debug|x64
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|x86.ActiveCfg = Debug|x86
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|x86.Build.0 = Debug|x86
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Debug|x86.Deploy.0 = Debug|x86
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|ARM.ActiveCfg = Release|ARM
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|ARM.Build.0 = Release|ARM
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|ARM.Deploy.0 = Release|ARM
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|x64.ActiveCfg = Release|x64
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|x64.Build.0 = Release|x64
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|x64.Deploy.0 = Release|x64
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|x86.ActiveCfg = Release|x86
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|x86.Build.0 = Release|x86
+		{CF1CD0D5-BF6B-457A-9927-8079FC667CA4}.Release|x86.Deploy.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 EndGlobal
-
-

--- a/Samples/FolderEnumeration/cs/Package.appxmanifest
+++ b/Samples/FolderEnumeration/cs/Package.appxmanifest
@@ -21,7 +21,7 @@
     </Properties>
 
     <Dependencies>
-        <TargetDeviceFamily Name="Windows.Mobile" MinVersion="10.0.10240.0" MaxVersionTested="10.0.10240.0" />
+        <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.10240.0" MaxVersionTested="10.0.10240.0" />
     </Dependencies>
 
     <Resources>

--- a/Samples/FolderEnumeration/cs/Scenario3.xaml.cs
+++ b/Samples/FolderEnumeration/cs/Scenario3.xaml.cs
@@ -90,7 +90,7 @@ namespace SDKTemplate
 
             // Set up the query and retrieve files.
             StorageFolder testFolder     = KnownFolders.PicturesLibrary;
-            testFolder = await testFolder.GetFolderAsync("EnumTest");
+//            testFolder = await testFolder.GetFolderAsync("EnumTest");
 
             var query = testFolder.CreateItemQueryWithOptions(queryOptions);
 

--- a/Samples/FolderEnumeration/shared/Scenario3.xaml
+++ b/Samples/FolderEnumeration/shared/Scenario3.xaml
@@ -42,9 +42,11 @@
                         Make sure there are picture files in your Pictures library before running the scenario.
                     </TextBlock>
                     <StackPanel Orientation="Horizontal">
-                        <Button x:Name="GetFilesButton" Content="Get files" Click="GetFilesButton_Click" Margin="0,10,0,0"/>
                         <TextBlock Text="Max files" VerticalAlignment="Center" Margin="10,10,10,0" />
                         <TextBox x:Name="MaxFilesText" Width="100" Margin="0,10,0,0"/>
+                        <CheckBox x:Name="PrefetchCheck" Content="Use Prefetch" Margin="10,10,0,0" />
+                        <Button x:Name="GetFilesButton" Content="Get files" Click="GetFilesButton_Click" Margin="0,10,0,0"/>
+                        <TextBlock x:Name="ScanProgressText" VerticalAlignment="Center" Width="Auto" Margin="10,10,10,0" />
                     </StackPanel>
                     <StackPanel x:Name="OutputPanel" Margin="0,10,0,0"/>
                 </StackPanel>

--- a/Samples/FolderEnumeration/shared/Scenario3.xaml
+++ b/Samples/FolderEnumeration/shared/Scenario3.xaml
@@ -34,14 +34,18 @@
             <ScrollViewer Grid.Row="1" VerticalScrollMode="Auto" VerticalScrollBarVisibility="Auto">
                 <StackPanel>
                     <TextBlock TextWrapping="Wrap" Style="{StaticResource BasicTextStyle}">
-                        Get all files in the Pictures library, along with properties and thumbnails. This sample uses 
+                        Get n files from the Pictures library, along with properties and thumbnails. This sample uses 
                         SetPropertyPrefetch and SetThumbnailPrefetch to access properties for large batches of files 
                         efficiently. Use this pattern to populate a database or a ListView (using a custom datasource 
                         like VirtualizedDataSource) with file system items.
                         <LineBreak/><LineBreak/>
                         Make sure there are picture files in your Pictures library before running the scenario.
                     </TextBlock>
-                    <Button x:Name="GetFilesButton" Content="Get files" Click="GetFilesButton_Click" Margin="0,10,0,0"/>
+                    <StackPanel Orientation="Horizontal">
+                        <Button x:Name="GetFilesButton" Content="Get files" Click="GetFilesButton_Click" Margin="0,10,0,0"/>
+                        <TextBlock Text="Max files" VerticalAlignment="Center" Margin="10,10,10,0" />
+                        <TextBox x:Name="MaxFilesText" Width="100" Margin="0,10,0,0"/>
+                    </StackPanel>
                     <StackPanel x:Name="OutputPanel" Margin="0,10,0,0"/>
                 </StackPanel>
             </ScrollViewer>


### PR DESCRIPTION
Just in case you'd like it, I made some steps to provide a StorageChangedTrigger test case to add to the background task sample.  Being mostly a C#/XAML guy, I didn't complete the cpp, java cases, but the C# should work pretty well.

The pull request adds a scenario 6 which registers the background trigger to fire whenever the photolibrary changes.  The background task fires at that time and lists the number of files in the library, in a deep query.

One should notice that this sample may not work in the local machine if the newest VS and SDK, OS is not used.  The older versions used to issue an "Element not found" exception upon trying to register the trigger, but now with the newest bits, that doesn't happen.

The sample now has been tested to work on desktop and mobile.

Thanks for your help in the past, and whatever you do with this one, Happy Holidays.
