### PR TITLE
Fix NavigationMenu sample

### DIFF
--- a/Samples/XamlNavigation/cs/App.xaml
+++ b/Samples/XamlNavigation/cs/App.xaml
@@ -2,7 +2,6 @@
     x:Class="NavigationMenuSample.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:c="using:NavigationMenuSample.Common"
     xmlns:local="using:NavigationMenuSample">
 
     <Application.Resources>

--- a/Samples/XamlNavigation/cs/AppShell.xaml
+++ b/Samples/XamlNavigation/cs/AppShell.xaml
@@ -74,21 +74,23 @@
                                           ItemInvoked="NavMenuList_ItemInvoked" />
             </SplitView.Pane>
 
-            <!-- OnNavigatingToPage we synchronize the selected item in the nav menu with the current page.
+            <SplitView.Content>
+                <!-- OnNavigatingToPage we synchronize the selected item in the nav menu with the current page.
                  OnNavigatedToPage we move keyboard focus to the first item on the page after it's loaded and update the Back button. -->
-            <Frame x:Name="frame"
+                <Frame x:Name="frame"
                    Navigating="OnNavigatingToPage"
                    Navigated="OnNavigatedToPage">
-                <Frame.ContentTransitions>
-                    <TransitionCollection>
-                        <NavigationThemeTransition>
-                            <NavigationThemeTransition.DefaultNavigationTransitionInfo>
-                                <EntranceNavigationTransitionInfo/>
-                            </NavigationThemeTransition.DefaultNavigationTransitionInfo>
-                        </NavigationThemeTransition>
-                    </TransitionCollection>
-                </Frame.ContentTransitions>
-            </Frame>
+                    <Frame.ContentTransitions>
+                        <TransitionCollection>
+                            <NavigationThemeTransition>
+                                <NavigationThemeTransition.DefaultNavigationTransitionInfo>
+                                    <EntranceNavigationTransitionInfo/>
+                                </NavigationThemeTransition.DefaultNavigationTransitionInfo>
+                            </NavigationThemeTransition>
+                        </TransitionCollection>
+                    </Frame.ContentTransitions>
+                </Frame>
+            </SplitView.Content>
         </SplitView>
 
         <!-- Declared last to have it rendered above everything else, but it needs to be the first item in the tab sequence. -->


### PR DESCRIPTION
App.xaml: Removed reference to nonexistent namespace.
AppShell.xaml: Frame needs to be placed within the SliptView.Content
property to prevent Visual Studio from throwing errors and
impossibilitating its visualization on the Design view.