### PR TITLE
fix copypaste error in LocationTrackingReason

### DIFF
--- a/Samples/ExtendedExecution/cs/Scenario3_LocationTrackingReason.xaml.cs
+++ b/Samples/ExtendedExecution/cs/Scenario3_LocationTrackingReason.xaml.cs
@@ -110,7 +110,7 @@ namespace SDKTemplate
             ClearExtendedExecution();
 
             var newSession = new ExtendedExecutionSession();
-            newSession.Reason = ExtendedExecutionReason.Unspecified;
+            newSession.Reason = ExtendedExecutionReason.LocationTracking;
             newSession.Description = "Tracking your location";
             newSession.Revoked += SessionRevoked;
             ExtendedExecutionResult result = await newSession.RequestExtensionAsync();


### PR DESCRIPTION
I've changed value to newSession.Reason = ExtendedExecutionReason.LocationTracking; 'cause it's a Location Tracking sample. 