### PR TITLE
XamlNavigation: add proper <SplitView.Content> tag to splitview

### DIFF
--- a/Samples/XamlNavigation/shared/AppShell.xaml
+++ b/Samples/XamlNavigation/shared/AppShell.xaml
@@ -122,23 +122,24 @@
                             ToolTipService.ToolTip="Settings"/>
                 </Grid>
             </SplitView.Pane>
-
-            <!-- OnNavigatingToPage we synchronize the selected item in the nav menu with the current page.
-                 OnNavigatedToPage we move keyboard focus to the first item on the page after it's loaded and update the Back button. -->
-            <Frame x:Name="frame"
-                   Margin="0,4,0,0"
-                   Navigating="OnNavigatingToPage"
-                   Navigated="OnNavigatedToPage">
-                <Frame.ContentTransitions>
-                    <TransitionCollection>
-                        <NavigationThemeTransition>
-                            <NavigationThemeTransition.DefaultNavigationTransitionInfo>
-                                <EntranceNavigationTransitionInfo/>
-                            </NavigationThemeTransition.DefaultNavigationTransitionInfo>
-                        </NavigationThemeTransition>
-                    </TransitionCollection>
-                </Frame.ContentTransitions>
-            </Frame>
+            <SplitView.Content>
+                <!-- OnNavigatingToPage we synchronize the selected item in the nav menu with the current page.
+                     OnNavigatedToPage we move keyboard focus to the first item on the page after it's loaded and update the Back button. -->
+                <Frame x:Name="frame"
+                       Margin="0,4,0,0"
+                       Navigating="OnNavigatingToPage"
+                       Navigated="OnNavigatedToPage">
+                    <Frame.ContentTransitions>
+                        <TransitionCollection>
+                            <NavigationThemeTransition>
+                                <NavigationThemeTransition.DefaultNavigationTransitionInfo>
+                                    <EntranceNavigationTransitionInfo/>
+                                </NavigationThemeTransition.DefaultNavigationTransitionInfo>
+                            </NavigationThemeTransition>
+                        </TransitionCollection>
+                    </Frame.ContentTransitions>
+                </Frame>
+            </SplitView.Content>
         </SplitView>
 
         <!-- Declared last to have it rendered above everything else, but it needs to be the first item in the tab sequence. -->


### PR DESCRIPTION
Simply adding a <SplitView.Content> tag around the <Frame> content will make the complier warning go away.. and is likely the proper way to enclose this content.

Severity	Code	Description	Project	File	Line	Suppression State
_Error		Cannot add content to an object of type "SplitView".	NavigationMenu	C:\Users\Herrick\Documents\Visual Studio 2015\Projects\Windows-universal-samples\Samples\XamlNavigation\shared\AppShell.xaml	128_	

This error DOES go away after a build... and doesn't prevent running. However, since this is sample code for others to use, should be properly updated.