### PR TITLE
 Update AllJoyn Consumer Experience Demo App to interop with IoT Onbo…

### DIFF
--- a/Samples/AllJoyn/ConsumerExperiences/cs/Scenario2ViewModel.cs
+++ b/Samples/AllJoyn/ConsumerExperiences/cs/Scenario2ViewModel.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Windows.Devices.AllJoyn;
@@ -59,13 +60,12 @@ namespace AllJoynConsumerExperiences
         private bool? m_physicalDeviceIsChecked = null;
         private bool m_showOnboardeeSsidList = true;
         private bool m_showOnboarderSsidList = false;
-        private bool m_isAuthenticated = false;
-        private bool m_isCredentialsRequested = false;
         private AllJoynBusAttachment m_busAttachment = null;
         private OnboardingWatcher m_watcher = null;
         private OnboardingConsumer m_consumer = null;
         private OnboardingAuthenticationType m_selectedAuthType = OnboardingAuthenticationType.Any;
         private TaskCompletionSource<bool> m_authenticateClicked = null;
+        private int m_onboardSessionAlreadyJoined;
 
         public Scenario2ViewModel()
         {
@@ -681,9 +681,13 @@ namespace AllJoynConsumerExperiences
         {
             ScenarioCleanup();
 
+            // Allow re-joining of a new session
+            Interlocked.Exchange(ref m_onboardSessionAlreadyJoined, 0);
+
             m_busAttachment = new AllJoynBusAttachment();
             m_busAttachment.StateChanged += BusAttachment_StateChanged;
             m_busAttachment.AuthenticationMechanisms.Clear();
+            m_busAttachment.AuthenticationMechanisms.Add(AllJoynAuthenticationMechanism.EcdheNull);
             m_busAttachment.AuthenticationMechanisms.Add(AllJoynAuthenticationMechanism.EcdhePsk);
             m_busAttachment.AuthenticationComplete += BusAttachment_AuthenticationComplete;
             m_busAttachment.CredentialsRequested += BusAttachment_CredentialsRequested;
@@ -712,8 +716,7 @@ namespace AllJoynConsumerExperiences
             {
                 UpdateStatusAsync("Authentication failed.", NotifyType.ErrorMessage);
             }
-
-            m_isAuthenticated = args.Succeeded;
+            
             EnteredKey = "";
             AuthenticationVisibility = Visibility.Collapsed;
         }
@@ -721,7 +724,6 @@ namespace AllJoynConsumerExperiences
         private async void BusAttachment_CredentialsRequested(AllJoynBusAttachment sender, AllJoynCredentialsRequestedEventArgs args)
         {
             Windows.Foundation.Deferral credentialsDeferral = args.GetDeferral();
-            m_isCredentialsRequested = true;
 
             if (args.Credentials.AuthenticationMechanism == AllJoynAuthenticationMechanism.EcdhePsk)
             {
@@ -741,6 +743,9 @@ namespace AllJoynConsumerExperiences
                     UpdateStatusAsync("Please enter a key.", NotifyType.ErrorMessage);
                 }
             }
+            else if (args.Credentials.AuthenticationMechanism == AllJoynAuthenticationMechanism.EcdheNull)
+            {
+            }
             else
             {
                 UpdateStatusAsync("Unexpected authentication mechanism.", NotifyType.ErrorMessage);
@@ -751,18 +756,25 @@ namespace AllJoynConsumerExperiences
 
         private async void Watcher_Added(OnboardingWatcher sender, AllJoynServiceInfo args)
         {
+            // This demo supports a single onboarding producer, if there are multiple onboarding producers found, then they are ignored.
+            // Another approach would be to create a list of all producers found and then allow the user to choose the one they want
+            bool bAlreadyJoined = (Interlocked.CompareExchange(ref m_onboardSessionAlreadyJoined, 1, 0) == 1);
+            if (bAlreadyJoined)
+            {
+                return;
+            }
+
             UpdateStatusAsync("Joining session...", NotifyType.StatusMessage);
+
             OnboardingJoinSessionResult joinSessionResult = await OnboardingConsumer.JoinSessionAsync(args, sender);
             if (joinSessionResult.Status == AllJoynStatus.Ok)
             {
+                UpdateStatusAsync("Session Joined.", NotifyType.ErrorMessage);
                 DisposeConsumer();
-                m_consumer = joinSessionResult.Consumer;
+                m_consumer = joinSessionResult.Consumer;                
                 m_consumer.SessionLost += Consumer_SessionLost;
 
-                if (!m_isCredentialsRequested || m_isAuthenticated)
-                {
-                    GetOnboardeeNetworkListAsync();
-                }
+                GetOnboardeeNetworkListAsync();
             }
             else
             {
@@ -869,8 +881,8 @@ namespace AllJoynConsumerExperiences
             else
             {
                 UpdateStatusAsync("Attempting to configure onboardee...", NotifyType.StatusMessage);
-                // WiFi password must be converted to hex representation of the UTF-8 string.
-                OnboardingConfigureWiFiResult configureWifiResult = await m_consumer.ConfigureWiFiAsync(ssid, ConvertUtf8ToHex(password), authType);
+                
+                OnboardingConfigureWiFiResult configureWifiResult = await m_consumer.ConfigureWiFiAsync(ssid, password, authType);
                 if (configureWifiResult.Status == AllJoynStatus.Ok)
                 {
                     UpdateStatusAsync("Onboardee sucessfully configured.", NotifyType.StatusMessage);
@@ -909,18 +921,6 @@ namespace AllJoynConsumerExperiences
             else
             {
                 UpdateStatusAsync(string.Format("Connection attempt failed with result code: {0} and message: {1}.", ((ConnectionResultCode)args.Arg.Value1).ToString(), args.Arg.Value2), NotifyType.ErrorMessage);
-            }
-        }
-
-        private string ConvertUtf8ToHex(string inputString)
-        {
-            if (string.IsNullOrEmpty(inputString))
-            {
-                return string.Empty;
-            }
-            else
-            {
-                return BitConverter.ToString(Encoding.UTF8.GetBytes(inputString)).Replace("-", string.Empty);
             }
         }
 

--- a/Samples/AllJoyn/ProducerExperiences/cs/Scenario2ViewModel.cs
+++ b/Samples/AllJoyn/ProducerExperiences/cs/Scenario2ViewModel.cs
@@ -334,7 +334,7 @@ namespace AllJoynProducerExperiences
                         }
                         else
                         {
-                            if (AppData.OnboardingConfigurePassphrase.Equals(ConvertUtf8ToHex(AppData.SampleNetworkPassword), StringComparison.OrdinalIgnoreCase))
+                            if (AppData.OnboardingConfigurePassphrase.Equals(AppData.SampleNetworkPassword, StringComparison.OrdinalIgnoreCase))
                             {
                                 returnArg.Value1 = (short)ConnectionResultCode.Validated;
                                 returnArg.Value2 = "Connected successfully";
@@ -374,18 +374,6 @@ namespace AllJoynProducerExperiences
             else
             {
                 UpdateStatusAsync(string.Format("Onboarding Failed. Attempt to connect failed with result code: {0} and message: {1}.", ((ConnectionResultCode)returnArg.Value1).ToString(), returnArg.Value2), NotifyType.ErrorMessage);
-            }
-        }
-
-        private string ConvertUtf8ToHex(string inputString)
-        {
-            if (string.IsNullOrEmpty(inputString))
-            {
-                return string.Empty;
-            }
-            else
-            {
-                return BitConverter.ToString(Encoding.UTF8.GetBytes(inputString)).Replace("-", string.Empty);
             }
         }
 


### PR DESCRIPTION
…arding Demo App

 This change fixes an incompatibility between the AllJoyn Consumer Experience Demo and the Iot Onboarding Demo Application.  Specifically:

     1) The Password should not be converted to a Hex-ized ASCII string.  This change applies to both the Consumer and Producer Experience Demo.
     2) The Consumer Experience now provides support for handling both ECDHE_PSK and ECDHE_NULL authentication modes which are supported by the IoTOnboarding demo.
     3) The Consumer Experience reliability is improved in an environment with multiple producers; this change restricts session joins to the first joined AllJoyn Onboarding Producer.  Without this change, the Consumer app's state gets lost.
     (Note however that this incremental improvement does not allow the user to select from a list of producers which would be an even better solution.)
     4) The Consumer Experience Demo no longer checks if authentication has been performed or if credentials are required.  These items are handled by the AllJoyn service automatically and there is no need to track them.