### PR TITLE
Fix build errors when using Visual Studio 2015 Update 3.

### DIFF
--- a/Samples/AllJoyn/Common/Scenario1WinRTComponent/SecureInterfaceStructures.h
+++ b/Samples/AllJoyn/Common/Scenario1WinRTComponent/SecureInterfaceStructures.h
@@ -73,19 +73,19 @@ public:
         return m_vector->GetView();
     }
 
-    virtual void SetAt(unsigned int index, Platform::Object^ item)
+    virtual void SetAt(unsigned int index, Platform::Object^ value)
     {
-        return m_vector->SetAt(index, item);
+        return m_vector->SetAt(index, value);
     }
 
-    virtual void InsertAt(unsigned int index, Platform::Object^ item)
+    virtual void InsertAt(unsigned int index, Platform::Object^ value)
     {
-        return m_vector->InsertAt(index, item);
+        return m_vector->InsertAt(index, value);
     }
 
-    virtual void Append(Platform::Object^ item)
+    virtual void Append(Platform::Object^ value)
     {
-        return m_vector->Append(item);
+        return m_vector->Append(value);
     }
 
     virtual void RemoveAt(unsigned int index)
@@ -103,9 +103,9 @@ public:
         return m_vector->Clear();
     }
 
-    virtual void ReplaceAll(const Platform::Array<Platform::Object^>^ arr)
+    virtual void ReplaceAll(const Platform::Array<Platform::Object^>^ items)
     {
-        return m_vector->ReplaceAll(arr);
+        return m_vector->ReplaceAll(items);
     }
 
 private:

--- a/Samples/AllJoyn/Common/Scenario2WinRTComponent/OnboardingStructures.h
+++ b/Samples/AllJoyn/Common/Scenario2WinRTComponent/OnboardingStructures.h
@@ -133,19 +133,19 @@ public:
         return m_vector->GetView();
     }
 
-    virtual void SetAt(unsigned int index, Platform::Object^ item)
+    virtual void SetAt(unsigned int index, Platform::Object^ value)
     {
-        return m_vector->SetAt(index, item);
+        return m_vector->SetAt(index, value);
     }
 
-    virtual void InsertAt(unsigned int index, Platform::Object^ item)
+    virtual void InsertAt(unsigned int index, Platform::Object^ value)
     {
-        return m_vector->InsertAt(index, item);
+        return m_vector->InsertAt(index, value);
     }
 
-    virtual void Append(Platform::Object^ item)
+    virtual void Append(Platform::Object^ value)
     {
-        return m_vector->Append(item);
+        return m_vector->Append(value);
     }
 
     virtual void RemoveAt(unsigned int index)
@@ -163,9 +163,9 @@ public:
         return m_vector->Clear();
     }
 
-    virtual void ReplaceAll(const Platform::Array<Platform::Object^>^ arr)
+    virtual void ReplaceAll(const Platform::Array<Platform::Object^>^ items)
     {
-        return m_vector->ReplaceAll(arr);
+        return m_vector->ReplaceAll(items);
     }
 
 private:


### PR DESCRIPTION
Parameter names must match the interface being implemented, or the compilation will fail..
There's no actual code changes. Just change to variable names so they match the interface they implement.