### PR TITLE
Fixed ListView control example code that had missing bracket

### DIFF
--- a/Samples/XamlUIBasics/cs/AppUIBasics/ControlPages/ListViewPage.xaml
+++ b/Samples/XamlUIBasics/cs/AppUIBasics/ControlPages/ListViewPage.xaml
@@ -110,21 +110,20 @@
                 <RichTextBlock>
                     <Paragraph>&lt;ListView ItemsSource="{x:Bind Groups}"</Paragraph>
                     <Paragraph TextIndent="36">ItemTemplate="{StaticResource
-                        <Run x:Name="itemTemplate">ImageTextListTemplate</Run> }"
+                        <Run x:Name="itemTemplate">ImageTextListTemplate</Run>}"
                     </Paragraph>
-                    <Paragraph TextIndent="36">IsItemClickEnabled="
-                        <Run Text="{x:Bind Control1.IsItemClickEnabled, Converter={StaticResource valueToStringConverter}, Mode=OneWay}"></Run> "
+                    <Paragraph TextIndent="36">
+                        IsItemClickEnabled="<Run Text="{x:Bind Control1.IsItemClickEnabled, Converter={StaticResource valueToStringConverter}, Mode=OneWay}"></Run>"
                     </Paragraph>
-                    <Paragraph TextIndent="36">IsSwipeEnabled="
-                        <Run Text="{x:Bind Control1.IsSwipeEnabled, Converter={StaticResource valueToStringConverter}, Mode=OneWay}"/> "
+                    <Paragraph TextIndent="36">
+                        IsSwipeEnabled="<Run Text="{x:Bind Control1.IsSwipeEnabled, Converter={StaticResource valueToStringConverter}, Mode=OneWay}"/>"
                     </Paragraph>
-                    <Paragraph TextIndent="36">CanDragItems="
-                        <Run Text="{x:Bind Control1.CanDragItems, Converter={StaticResource valueToStringConverter}, Mode=OneWay}"/> "
+                    <Paragraph TextIndent="36">
+                        CanDragItems="<Run Text="{x:Bind Control1.CanDragItems, Converter={StaticResource valueToStringConverter}, Mode=OneWay}"/>"
                     </Paragraph>
-                    <Paragraph TextIndent="36">SelectionMode="
-                        <Run Text="{x:Bind Control1.SelectionMode, Converter={StaticResource valueToStringConverter}, Mode=OneWay}"/> "
+                    <Paragraph TextIndent="36">
+                        SelectionMode="<Run Text="{x:Bind Control1.SelectionMode, Converter={StaticResource valueToStringConverter}, Mode=OneWay}"/>" /&gt;
                     </Paragraph>
-                    <Paragraph>&lt;/ListView&gt;</Paragraph>
                 </RichTextBlock>
             </local:ControlExample.Xaml>
         </local:ControlExample>


### PR DESCRIPTION
This pull requests fixes the code example generated for the ListView control in the _App UI Basics CS Sample_.

The generated code had additional spaces and the opening `ListView` tag wasn't closed.

Before:
![image](https://cloud.githubusercontent.com/assets/7553472/18332627/4ae0fc36-75bc-11e6-8ebe-9470e9215f5f.png)
![image](https://cloud.githubusercontent.com/assets/7553472/18332629/4d455d8c-75bc-11e6-8fea-ac6ef8b19aa3.png)

After:
![image](https://cloud.githubusercontent.com/assets/7553472/18332632/52adef3c-75bc-11e6-8a39-803655c58ee7.png)
![image](https://cloud.githubusercontent.com/assets/7553472/18332635/5581ed44-75bc-11e6-93bb-09180a70523e.png)
