### PR TITLE
Something about NFC

### DIFF
--- a/Samples/Nfc/PcscSdk/Iso7816.cs
+++ b/Samples/Nfc/PcscSdk/Iso7816.cs
@@ -170,13 +170,15 @@ namespace Iso7816
                         throw new Exception("Invalid length for TLV response");
 
                     valueLength = reader.ReadByte();
-                    lengthLength = 1;
 
                     if ((valueLength & TAG_LENGTH_MULTI_BYTE_MASK) == TAG_LENGTH_MULTI_BYTE_MASK)
-                        lengthLength += (valueLength & ~TAG_LENGTH_MULTI_BYTE_MASK);
+                    {
+                        lengthLength = 1 + (valueLength & ~TAG_LENGTH_MULTI_BYTE_MASK);
 
-                    while (--lengthLength > 0)
-                        valueLength = (valueLength << 8) | reader.ReadByte();
+                        valueLength = 0;
+                        while (--lengthLength > 0)
+                            valueLength = (valueLength << 8) | reader.ReadByte();
+                    }
 
                     while (valueLength != 0 && valueLength-- > 0)
                         value.WriteByte(reader.ReadByte());

--- a/Samples/Nfc/PcscSdk/Iso7816.cs
+++ b/Samples/Nfc/PcscSdk/Iso7816.cs
@@ -24,9 +24,9 @@ namespace Iso7816
     {
         public ApduCommand(byte cla, byte ins, byte p1, byte p2, byte[] commandData, byte? le)
         {
-            if (commandData != null && commandData.Length > 254)
+            if (commandData != null && commandData.Length > 0xFFFF)
             {
-                throw new NotImplementedException();
+                throw new Exception("CommandData exceeded max length.");
             }
             CLA = cla;
             INS = ins;
@@ -83,6 +83,11 @@ namespace Iso7816
 
                 if (CommandData != null && CommandData.Length > 0)
                 {
+                    if (CommandData.Length > 0xFF)
+                    {
+                        writer.WriteByte(0x00);
+                        writer.WriteByte((byte)(CommandData.Length >> 8));
+                    }
                     writer.WriteByte((byte)CommandData.Length);
                     writer.WriteBytes(CommandData);
                 }


### PR DESCRIPTION
I read these TLV bytes from my credit card.
`7081B49F4681B0A1C70DB39980B4E79F81D8730E6A511E306109DA40F3F07BC25EB55783C2783BE5CB6857599F0E5B9EEBB4BDDD3FB079D4645073708B54AE104C854442A17D4B4619D79AD6E4C8AD9641CC010FE145E538343F30668C8A28D6D7BA83661E4EAA5D668DA3DC6B6684BE5717E1DB9DC9D9E110F14937329B110B8C42E4FA2EFAB299C5D4B95F001CD4F93C3D9059ED971AE2DB038F6DEF92F5FC50A1864DDC0D92292F9F6618FB437078898CD55610EA2D9000`

but got an out-of-range exception when extracting the TLV Data.
I find that the code doesn't recognize multi-bytes length field. So I try to fixed it.



And I implemented some function in TLVEntry and ApdbCommand.
