### PR TITLE
Update C# Share Target example to allow resourceMap images to show up in web view.

### DIFF
--- a/Samples/ShareTarget/cs/ShareTarget.xaml.cs
+++ b/Samples/ShareTarget/cs/ShareTarget.xaml.cs
@@ -292,13 +292,16 @@ namespace SDKTemplate
                                 foreach (KeyValuePair<string, RandomAccessStreamReference> item in this.sharedResourceMap)
                                 {
                                     var stream = await item.Value.OpenReadAsync();
+                                    if (!stream.ContentType.Contains("image/"))
+                                        continue;
                                     var reader = new DataReader(stream.GetInputStreamAt(0));
                                     await reader.LoadAsync((uint)stream.Size);
                                     byte[] byteArray = new byte[stream.Size];
                                     reader.ReadBytes(byteArray);
-                                    String base64String = "'data:image/gif;base64," + Convert.ToBase64String(byteArray) + "'";
+                                    String base64String = "<img src ='data:image/gif;base64," + Convert.ToBase64String(byteArray) + "'";
+                                    String replaceTarget = "<img src=" + item.Key;
 
-                                    htmlFragment = htmlFragment.Replace(item.Key, base64String);
+                                    htmlFragment = htmlFragment.Replace(replaceTarget, base64String);
                                 }
                             }
 

--- a/Samples/ShareTarget/cs/ShareTarget.xaml.cs
+++ b/Samples/ShareTarget/cs/ShareTarget.xaml.cs
@@ -286,6 +286,22 @@ namespace SDKTemplate
                         {
                             AddContentValue("HTML: ");
                             ShareWebView.Visibility = Visibility.Visible;
+                            // Check if there are any local images in the resource map.
+                            if (this.sharedResourceMap.Count > 0)
+                            {
+                                foreach (KeyValuePair<string, RandomAccessStreamReference> item in this.sharedResourceMap)
+                                {
+                                    var stream = await item.Value.OpenReadAsync();
+                                    var reader = new DataReader(stream.GetInputStreamAt(0));
+                                    await reader.LoadAsync((uint)stream.Size);
+                                    byte[] byteArray = new byte[stream.Size];
+                                    reader.ReadBytes(byteArray);
+                                    String base64String = "'data:image/gif;base64," + Convert.ToBase64String(byteArray) + "'";
+
+                                    htmlFragment = htmlFragment.Replace(item.Key, base64String);
+                                }
+                            }
+
                             ShareWebView.NavigateToString("<html><body>" + htmlFragment + "</body></html>");
                         }
                         else


### PR DESCRIPTION
Update C# Share Target example to allow resourceMap images to show up in web view.
In RS2, Edge has a new feature 'Saved Tabs' that is sharing images out as resourceMap