### PR TITLE
Remove invalid ProjectReference

### DIFF
--- a/Samples/BluetoothLE/cs/BluetoothLE.csproj
+++ b/Samples/BluetoothLE/cs/BluetoothLE.csproj
@@ -179,12 +179,6 @@
       <Link>Assets\windows-sdk.png</Link>
     </Content>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Shared\Shared.csproj">
-      <Project>{9860d297-fb11-48e5-8fee-26727c4d8db4}</Project>
-      <Name>Shared</Name>
-    </ProjectReference>
-  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>


### PR DESCRIPTION
This BLE Sample project will not build as the 'shared' reference appears to be missing. A search of other samples shows that this is the only project containing this reference so I believe it is outdated and should have been removed. The sample builds and deploys successfully after removing this reference.