### PR TITLE
Fix for runtime error ('Text' property of 'TextBlock' expects 'string…

### DIFF
--- a/Samples/XamlListView/cs/Model/Contact.cs
+++ b/Samples/XamlListView/cs/Model/Contact.cs
@@ -113,7 +113,7 @@ namespace ListViewSample.Model
             foreach (var g in query)
             {
                 GroupInfoList info = new GroupInfoList();
-                info.Key = g.GroupName;
+                info.Key = g.GroupName.ToString();
                 foreach (var item in g.Items)
                 {
                     info.Add(item);


### PR DESCRIPTION
Refer to line 78 of 'SimpleListViewSample.xaml' as an example of the runtime error