### PR TITLE
Change the TargetPlatformVersion to 16299

### DIFF
--- a/Samples/XamlUIBasics/cs/AppUIBasics/AppUIBasics.csproj
+++ b/Samples/XamlUIBasics/cs/AppUIBasics/AppUIBasics.csproj
@@ -10,8 +10,8 @@
     <AssemblyName>AppUIBasics</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.16288.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16288.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>
@@ -812,7 +812,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.0.0</Version>
+      <Version>6.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.0</Version>


### PR DESCRIPTION
Cannot open/load the AppUIBasics solution/project because the TargetPlatformMinVersion and TargetPlatformVersion is 16288. To support the latest Windows SDK 16299.15, the TargetPlatformVersion should be 16299.

``` xml
    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
    <TargetPlatformMinVersion>10.0.16288.0</TargetPlatformMinVersion>
```