### PR TITLE
Added GSSetShader (null) call for getting rid of  Geometry Shader linkage error

### DIFF
--- a/Samples/360VideoPlayback/cpp/Content/VideoRenderer.cpp
+++ b/Samples/360VideoPlayback/cpp/Content/VideoRenderer.cpp
@@ -109,6 +109,14 @@ void VideoRenderer::Render()
             0
         );
     }
+    else 
+    {
+        context->GSSetShader(
+            nullptr,
+            nullptr,
+            0
+        );
+    }
 
     // Attach the pixel shader.
     context->PSSetShader(


### PR DESCRIPTION
On certain GPUs, there is Geometry Shader linkage error when using VPRT, but not calling GSSetShader with all nulls.