### PR TITLE
Fix for box.3mf asset getting renamed.

### DIFF
--- a/Samples/MapControl/cs/MapControl.csproj
+++ b/Samples/MapControl/cs/MapControl.csproj
@@ -281,7 +281,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="..\shared\box.3mf">
-      <Link>Assets\ConkerAfro.3mf</Link>
+      <Link>Assets\box.3mf</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="..\shared\MyCustomStates.json">


### PR DESCRIPTION
box.3mf asset was being copied to a file with a different file name. This causes a scenario in the app to fail because the expected file (box.3mf) could not be found.