### PR TITLE
Add IoT to supported device types

### DIFF
--- a/Samples/XamlUIBasics/cs/AppUIBasics/Navigation/NavigationRootPage.xaml.cs
+++ b/Samples/XamlUIBasics/cs/AppUIBasics/Navigation/NavigationRootPage.xaml.cs
@@ -218,6 +218,7 @@ namespace AppUIBasics
     public enum DeviceType
     {
         Desktop,
+        IoT,
         Mobile,
         Xbox
     }


### PR DESCRIPTION
Supported device types currently do not include IoT. This change adds it. Without this change, the app will crash with an exception NotSupportedException("Unsupported device family.").
The fix was tested on Windows 10 IoTCore 16299.