### PR TITLE
Fixed comment about NV12 format

### DIFF
--- a/Samples/HolographicFaceTracking/cpp/Content/NV12VideoTexture.cpp
+++ b/Samples/HolographicFaceTracking/cpp/Content/NV12VideoTexture.cpp
@@ -118,7 +118,7 @@ concurrency::task<void> NV12VideoTexture::CreateDeviceDependentResourcesAsync()
         );
 
         // DirectX specifies the view format to be DXGI_FORMAT_R8G8_UNORM for NV12 chrominance channel.
-        // Chrominance has 4 bits for U and 4 bits for V per pixel. DirectX will handle converting 4-bit
+        // Chrominance has 8 bits for U and 8 bits for V per pixel. DirectX will handle converting 8-bit
         // integers into normalized floats for use in the shader.
         D3D11_SHADER_RESOURCE_VIEW_DESC const chrominancePlaneDesc = CD3D11_SHADER_RESOURCE_VIEW_DESC(
             m_texture.Get(),

--- a/Samples/HolographicFaceTracking/cpp/Content/NV12VideoTexture.cpp
+++ b/Samples/HolographicFaceTracking/cpp/Content/NV12VideoTexture.cpp
@@ -118,8 +118,8 @@ concurrency::task<void> NV12VideoTexture::CreateDeviceDependentResourcesAsync()
         );
 
         // DirectX specifies the view format to be DXGI_FORMAT_R8G8_UNORM for NV12 chrominance channel.
-        // Chrominance has 8 bits for U and 8 bits for V per pixel. DirectX will handle converting 8-bit
-        // integers into normalized floats for use in the shader.
+        // Chrominance has 8 bits for U and 8 bits for V per sample (1 sample per 2x2 block of pixels).
+        //  DirectX will handle converting 8-bit integers into normalized floats for use in the shader.
         D3D11_SHADER_RESOURCE_VIEW_DESC const chrominancePlaneDesc = CD3D11_SHADER_RESOURCE_VIEW_DESC(
             m_texture.Get(),
             D3D11_SRV_DIMENSION_TEXTURE2D,


### PR DESCRIPTION
Changed comment to reflect that U & V samples each have 8 bits and that stored U & V values correspond to chrominance samples, not pixels (U & V have 2 bits per pixel).

From [Recommended 8-Bit YUV Formats for Video Rendering](https://msdn.microsoft.com/en-us/library/windows/desktop/dd206750%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396#nv12):

> The Y plane is followed immediately by an array of unsigned char values that contains packed U (Cb) and V (Cr) samples. When the combined U-V array is addressed as an array of little-endian WORD values, the LSBs contain the U values, and the MSBs contain the V values. 