### PR TITLE
Added NavigationViewItemHeader to sample code.

### DIFF
--- a/Samples/XamlUIBasics/cs/AppUIBasics/ControlPages/NavigationViewPage.xaml
+++ b/Samples/XamlUIBasics/cs/AppUIBasics/ControlPages/NavigationViewPage.xaml
@@ -45,6 +45,9 @@
                     <Run Text="&lt;NavigationViewItemSeparator/&gt;"/>
                 </Paragraph>
                 <Paragraph TextIndent='24'>
+                    <Run Text="&lt;NavigationViewItemHeader Content=&quot;Actions&quot; /&gt;"/>
+                </Paragraph>    
+                <Paragraph TextIndent='24'>
                     <Run Text="&lt;NavigationViewItem Icon=&quot;Save&quot; Content=&quot;Menu Item2&quot; Tag=&quot;SamplePage2&quot; /&gt;"/>
                 </Paragraph>
                 <Paragraph TextIndent='24'>
@@ -106,6 +109,9 @@
                 <Paragraph TextIndent='24'>
                     <Run Text="&lt;NavigationViewItemSeparator/&gt;"/>
                 </Paragraph>
+                <Paragraph TextIndent='24'>
+                    <Run Text="&lt;NavigationViewItemHeader Content=&quot;Actions&quot; /&gt;"/>
+                </Paragraph> 
                 <Paragraph TextIndent='24'>
                     <Run Text="&lt;NavigationViewItem Icon=&quot;Save&quot; Content=&quot;Menu Item2&quot; Tag=&quot;SamplePage2&quot; /&gt;"/>
                 </Paragraph>


### PR DESCRIPTION
The sample code is missing entries for the NavigationViewItemHeader used in the demo. This adds the text to the two versions of code that get displayed.