### PR TITLE
Update BasicHologram to use C++/WinRT from Windows SDK

### DIFF
--- a/Samples/BasicHologram/cppwinrt/BasicHologram.vcxproj
+++ b/Samples/BasicHologram/cppwinrt/BasicHologram.vcxproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\cppwinrt.2017.10.13.1\build\native\cppwinrt.props" Condition="Exists('packages\cppwinrt.2017.10.13.1\build\native\cppwinrt.props')" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0834b002-6027-5680-b4f7-0d7efa93ad9a}</ProjectGuid>
     <Keyword>HolographicApp</Keyword>
@@ -169,7 +168,6 @@
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <FxCompile Include="Content\PixelShader.hlsl">
@@ -218,16 +216,8 @@
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ImageContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\MeshContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ShaderGraphContentTask.targets" />
-    <Import Project="packages\cppwinrt.2017.10.13.1\build\native\cppwinrt.targets" Condition="Exists('packages\cppwinrt.2017.10.13.1\build\native\cppwinrt.targets')" />
   </ImportGroup>
   <PropertyGroup>
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);packages\cppwinrt.2017.10.13.1\build\native\include</IncludePath>
   </PropertyGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\cppwinrt.2017.10.13.1\build\native\cppwinrt.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\cppwinrt.2017.10.13.1\build\native\cppwinrt.props'))" />
-    <Error Condition="!Exists('packages\cppwinrt.2017.10.13.1\build\native\cppwinrt.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\cppwinrt.2017.10.13.1\build\native\cppwinrt.targets'))" />
-  </Target>
 </Project>

--- a/Samples/BasicHologram/cppwinrt/BasicHologram.vcxproj.filters
+++ b/Samples/BasicHologram/cppwinrt/BasicHologram.vcxproj.filters
@@ -74,7 +74,6 @@
     <FxCompile Include="Content\VPRTVertexShader.hlsl">
       <Filter>Content\Shaders</Filter>
     </FxCompile>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest" />

--- a/Samples/BasicHologram/cppwinrt/BasicHologramMain.cpp
+++ b/Samples/BasicHologram/cppwinrt/BasicHologramMain.cpp
@@ -383,8 +383,8 @@ void BasicHologramMain::OnLocatabilityChanged(SpatialLocator const& sender, winr
     case SpatialLocatability::Unavailable:
         // Holograms cannot be rendered.
     {
-        winrt::hstring message = L"Warning! Positional tracking is " + std::to_wstring(int(sender.Locatability())) + L".\n";
-        OutputDebugStringW(message.data());
+        std::wstring message = L"Warning! Positional tracking is " + std::to_wstring(static_cast<int32_t>(sender.Locatability())) + L".\n";
+        OutputDebugStringW(message.c_str());
     }
     break;
 

--- a/Samples/BasicHologram/cppwinrt/Common/DeviceResources.cpp
+++ b/Samples/BasicHologram/cppwinrt/Common/DeviceResources.cpp
@@ -190,7 +190,7 @@ void DX::DeviceResources::CreateDeviceResources()
     winrt::com_ptr<::IInspectable> object;
     winrt::check_hresult(CreateDirect3D11DeviceFromDXGIDevice(
         dxgiDevice.Get(),
-        winrt::put_abi(object)));
+        object.put()));
     m_d3dInteropDevice = object.as<IDirect3DDevice>();
 
     // Cache the DXGI adapter.

--- a/Samples/BasicHologram/cppwinrt/Common/DirectXHelper.h
+++ b/Samples/BasicHologram/cppwinrt/Common/DirectXHelper.h
@@ -35,7 +35,7 @@ namespace DX
         winrt::check_hresult(
             CreateDirect3D11SurfaceFromDXGISurface(
                 depthDxgiSurface.Get(),
-                winrt::put_abi(inspectableSurface)
+                inspectableSurface.put()
             ));
 
         return inspectableSurface.as<winrt::Windows::Graphics::DirectX::Direct3D11::IDirect3DSurface>();

--- a/Samples/BasicHologram/cppwinrt/packages.config
+++ b/Samples/BasicHologram/cppwinrt/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="cppwinrt" version="2017.10.13.1" targetFramework="native" />
-</packages>


### PR DESCRIPTION
...instead of the last one published on nuget.

I hope I've found the proper calls for getting the right pointers (it does run on the RS4 HoloLens emulator though, so I assume everything is fine).
Also, I couldn't figure out how to use `hstring` for that one debug output, so I've just changed it to `std::wstring` since that's what I'm accustomed to and it can also be passed easily into `OutputDebugString`.