### PR TITLE
Add lowLevel DeviceCapability to IoT samples

### DIFF
--- a/Samples/IoT-GPIO/cpp/Package.appxmanifest
+++ b/Samples/IoT-GPIO/cpp/Package.appxmanifest
@@ -46,4 +46,8 @@
       </uap:VisualElements>
     </Application>
   </Applications>
+  
+  <Capabilities>
+    <DeviceCapability Name="lowLevel" />
+  </Capabilities>
 </Package>

--- a/Samples/IoT-GPIO/cs/Package.appxmanifest
+++ b/Samples/IoT-GPIO/cs/Package.appxmanifest
@@ -46,4 +46,8 @@
       </uap:VisualElements>
     </Application>
   </Applications>
+
+  <Capabilities>
+    <DeviceCapability Name="lowLevel" />
+  </Capabilities>
 </Package>

--- a/Samples/IoT-GPIO/js/package.appxmanifest
+++ b/Samples/IoT-GPIO/js/package.appxmanifest
@@ -27,7 +27,7 @@
   </Resources>
 
   <Applications>
-    <Application 
+    <Application
       Id="App"
       StartPage="default.html">
 
@@ -46,4 +46,8 @@
       </uap:VisualElements>
     </Application>
   </Applications>
+
+  <Capabilities>
+    <DeviceCapability Name="lowLevel" />
+  </Capabilities>
 </Package>

--- a/Samples/IoT-I2C/cpp/Package.appxmanifest
+++ b/Samples/IoT-I2C/cpp/Package.appxmanifest
@@ -46,4 +46,8 @@
       </uap:VisualElements>
     </Application>
   </Applications>
+
+  <Capabilities>
+    <DeviceCapability Name="lowLevel" />
+  </Capabilities>
 </Package>

--- a/Samples/IoT-I2C/cs/Package.appxmanifest
+++ b/Samples/IoT-I2C/cs/Package.appxmanifest
@@ -46,4 +46,8 @@
       </uap:VisualElements>
     </Application>
   </Applications>
+
+  <Capabilities>
+    <DeviceCapability Name="lowLevel" />
+  </Capabilities>
 </Package>

--- a/Samples/IoT-I2C/js/package.appxmanifest
+++ b/Samples/IoT-I2C/js/package.appxmanifest
@@ -27,7 +27,7 @@
   </Resources>
 
   <Applications>
-    <Application 
+    <Application
       Id="App"
       StartPage="default.html">
       <uap:VisualElements
@@ -45,4 +45,8 @@
       </uap:VisualElements>
     </Application>
   </Applications>
+
+  <Capabilities>
+    <DeviceCapability Name="lowLevel" />
+  </Capabilities>
 </Package>

--- a/Samples/IoT-SPI/cpp/Package.appxmanifest
+++ b/Samples/IoT-SPI/cpp/Package.appxmanifest
@@ -46,4 +46,8 @@
       </uap:VisualElements>
     </Application>
   </Applications>
+
+  <Capabilities>
+    <DeviceCapability Name="lowLevel" />
+  </Capabilities>
 </Package>

--- a/Samples/IoT-SPI/cs/Package.appxmanifest
+++ b/Samples/IoT-SPI/cs/Package.appxmanifest
@@ -46,4 +46,8 @@
       </uap:VisualElements>
     </Application>
   </Applications>
+
+  <Capabilities>
+    <DeviceCapability Name="lowLevel" />
+  </Capabilities>
 </Package>

--- a/Samples/IoT-SPI/js/package.appxmanifest
+++ b/Samples/IoT-SPI/js/package.appxmanifest
@@ -27,7 +27,7 @@
   </Resources>
 
   <Applications>
-    <Application 
+    <Application
       Id="App"
       StartPage="default.html">
 
@@ -46,4 +46,8 @@
       </uap:VisualElements>
     </Application>
   </Applications>
+
+  <Capabilities>
+    <DeviceCapability Name="lowLevel" />
+  </Capabilities>
 </Package>


### PR DESCRIPTION
The lowLevel device capability is required to access GPIO, I2C, SPI.