### PR TITLE
RPCServer in project CustomCapability makes "dcomcnfg" unavailable

### DIFF
--- a/Samples/CustomCapability/Service/Interface/RpcInterface.Idl
+++ b/Samples/CustomCapability/Service/Interface/RpcInterface.Idl
@@ -12,7 +12,7 @@
 import "oaidl.idl";
 import "unknwn.idl";
 
-[uuid (906B0CE0-C70B-1067-B317-00DD010662DA),
+[uuid (793F4B24-33C4-4378-BF77-52EC8172CBD4),
 version(1.0),
 pointer_default(unique),
 ]

--- a/Samples/CustomCapability/Service/Server/RpcServer.cpp
+++ b/Samples/CustomCapability/Service/Server/RpcServer.cpp
@@ -28,7 +28,6 @@ using namespace RpcServer;
 const WCHAR* CustomCapabilityName = L"microsoft.hsaTestCustomCapability_q536wpkpf5cy2";
 
 bool ShutdownRequested;
-static RPC_BINDING_VECTOR* BindingVector = nullptr;
 
 void FreeSidArray(__inout_ecount(cSIDs) PSID* pSIDs, ULONG cSIDs)
 {
@@ -222,14 +221,6 @@ void RpcServerDisconnect()
     DWORD hResult = S_OK;
     ShutdownRequested = true;
     hResult = RpcServerUnregisterIf(RpcInterface_v1_0_s_ifspec, nullptr, 0);
-
-    RpcEpUnregister(RpcInterface_v1_0_s_ifspec, BindingVector, nullptr);
-
-    if (BindingVector != nullptr)
-    {
-        RpcBindingVectorFree(&BindingVector);
-        BindingVector = nullptr;
-    }
 }
 
 //

--- a/Samples/CustomCapability/Service/Server/RpcServer.cpp
+++ b/Samples/CustomCapability/Service/Server/RpcServer.cpp
@@ -184,24 +184,6 @@ DWORD RpcServerStart()
         goto end;
     }
 
-    hResult = RpcServerInqBindings(&BindingVector);
-
-    if (hResult != S_OK)
-    {
-        goto end;
-    }
-
-    hResult = RpcEpRegister(
-        RpcInterface_v1_0_s_ifspec,
-        BindingVector,
-        nullptr,
-        nullptr);
-
-    if (hResult != S_OK)
-    {
-        goto end;
-    }
-
     hResult = RpcServerListen(
         minCalls,
         RPC_C_LISTEN_MAX_CALLS_DEFAULT,


### PR DESCRIPTION
if we build and run the sample code of CustomCapability, the dcomcnfg will have an error. 
We found the reason is in RPCServer.cpp.

Here are solution：
1. need to update the UUID of the RPCInterface, the old one is used by a system server. (the new one in the branch is created by vs tool "guidgen.exe")
2. don't need to call "RpcEpRegister",  the CustomCapability works well without it.  (If we don't register the endpoint by it, and use old UUID of RPCInterface, anything works well, including dcomcnfg. )