### PR TITLE
Add XamlDragAndDrop sample showing dragging between ListViews

### DIFF
--- a/Samples/XamlDragAndDrop/cpp/DragAndDropSampleNative.vcxproj
+++ b/Samples/XamlDragAndDrop/cpp/DragAndDropSampleNative.vcxproj
@@ -101,10 +101,10 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-    <PropertyGroup>
-        <IncludePath>$(VC_IncludePath);$(UniversalCRT_IncludePath);$(WindowsSDK_IncludePath);..\..\..\SharedContent\cpp</IncludePath>
-    </PropertyGroup>
-    <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+  <PropertyGroup>
+    <IncludePath>$(VC_IncludePath);$(UniversalCRT_IncludePath);$(WindowsSDK_IncludePath);..\..\..\SharedContent\cpp</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <ClCompile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
@@ -158,6 +158,9 @@
     <ClInclude Include="Scenario3_StartDragAsync.xaml.h">
       <DependentUpon>Scenario3_StartDragAsync.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="Scenario4_MoveBetweenListView.xaml.h">
+      <DependentUpon>Scenario4_MoveBetweenListView.xaml</DependentUpon>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="..\..\..\SharedContent\xaml\App.xaml">
@@ -172,6 +175,7 @@
     <Page Include="..\..\..\SharedContent\xaml\Styles.xaml">
       <Link>Styles\Styles.xaml</Link>
     </Page>
+    <Page Include="Scenario4_MoveBetweenListView.xaml" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">
@@ -202,6 +206,9 @@
     </ClCompile>
     <ClCompile Include="Scenario3_StartDragAsync.xaml.cpp">
       <DependentUpon>Scenario3_StartDragAsync.xaml</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="Scenario4_MoveBetweenListView.xaml.cpp">
+      <DependentUpon>Scenario4_MoveBetweenListView.xaml</DependentUpon>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Samples/XamlDragAndDrop/cpp/DragAndDropSampleNative.vcxproj.filters
+++ b/Samples/XamlDragAndDrop/cpp/DragAndDropSampleNative.vcxproj.filters
@@ -39,6 +39,7 @@
     <Page Include="Scenario3_StartDragAsync.xaml" />
     <Page Include="..\..\..\SharedContent\cpp\MainPage.xaml" />
     <Page Include="..\..\..\SharedContent\xaml\Styles.xaml" />
+    <Page Include="Scenario4_MoveBetweenListView.xaml" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="Assets\dropcursor.png">

--- a/Samples/XamlDragAndDrop/cpp/SampleConfiguration.cpp
+++ b/Samples/XamlDragAndDrop/cpp/SampleConfiguration.cpp
@@ -19,5 +19,6 @@ Platform::Array<Scenario>^ MainPage::scenariosInner = ref new Platform::Array<Sc
 {
     { "ListView Drag and Drop and Reorder", "SDKTemplate.Scenario1_ListView" },
     { "Drag UI Customization", "SDKTemplate.Scenario2_DragUICustomization" },
-    { "StartDragAsync", "SDKTemplate.Scenario3_StartDragAsync" }
+    { "StartDragAsync", "SDKTemplate.Scenario3_StartDragAsync" },
+	{ "Move Between ListViews", "SDKTemplate.Scenario4_MoveBetweenListView" }
 };

--- a/Samples/XamlDragAndDrop/cpp/Scenario4_MoveBetweenListView.xaml
+++ b/Samples/XamlDragAndDrop/cpp/Scenario4_MoveBetweenListView.xaml
@@ -1,0 +1,57 @@
+<!-- 
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+-->
+<Page
+    x:Class="SDKTemplate.Scenario4_MoveBetweenListView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:DragAndDropSampleNative"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+        <StackPanel Margin="0,0,0,10" Grid.ColumnSpan="2">
+            <TextBlock Text="Description:" Style="{StaticResource SampleHeaderTextStyle}"/>
+            <TextBlock Style="{StaticResource ScenarioDescriptionTextStyle}" TextWrapping="Wrap" Text="This scenario illustrates how to use ListView's Drag and Drop to reorder single items while maintaining the requested position."/>
+        </StackPanel>
+
+        <TextBlock Grid.Row="1" Margin="8,4"
+                    VerticalAlignment="Bottom"
+                    Text="All Items"/>
+        <ListView x:Name="SourceListView"
+                    Grid.Row="2" Margin="8,4"
+                    AllowDrop="True" CanReorderItems="True" CanDragItems="True"
+                    DragOver="ListView_DragOver"
+                    Drop="ListView_Drop"
+                    DragItemsStarting="ListView_DragItemsStarting"/>
+        <TextBlock Grid.Row="1" Grid.Column="1" Margin="8,4"
+                    VerticalAlignment="Bottom"
+                    Text="Selection"/>
+        <ListView x:Name="TargetListView"
+                    Grid.Row="2" Grid.Column="1" Margin="8,4"
+                    AllowDrop="True" CanReorderItems="True" CanDragItems="True"
+                    DragOver="ListView_DragOver"
+                    Drop="ListView_Drop"
+                    DragItemsStarting="ListView_DragItemsStarting"/>
+    </Grid>
+</Page>

--- a/Samples/XamlDragAndDrop/cpp/Scenario4_MoveBetweenListView.xaml.cpp
+++ b/Samples/XamlDragAndDrop/cpp/Scenario4_MoveBetweenListView.xaml.cpp
@@ -1,0 +1,148 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+#include "pch.h"
+#include "Scenario4_MoveBetweenListView.xaml.h"
+
+using namespace concurrency;
+using namespace SDKTemplate;
+using namespace Platform;
+using namespace Platform::Collections;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+using namespace Windows::UI::Xaml::Controls::Primitives;
+using namespace Windows::UI::Xaml::Data;
+using namespace Windows::UI::Xaml::Input;
+using namespace Windows::UI::Xaml::Media;
+using namespace Windows::UI::Xaml::Navigation;
+using namespace Windows::ApplicationModel::DataTransfer;
+
+Scenario4_MoveBetweenListView::Scenario4_MoveBetweenListView() : rootPage(MainPage::Current)
+{
+    InitializeComponent();
+
+    _source = GetSampleData();
+    _target = ref new Vector<String^>();
+    SourceListView->ItemsSource = _source;
+    TargetListView->ItemsSource = _target;
+}
+
+Vector<String^>^ Scenario4_MoveBetweenListView::GetSampleData()
+{
+    return ref new Vector<String^>(
+    {
+        ref new String(L"My Research Paper"),
+        ref new String(L"Electricity Bill"),
+        ref new String(L"My To-do list"),
+        ref new String(L"TV sales receipt"),
+        ref new String(L"Water Bill"),
+        ref new String(L"Grocery List"),
+        ref new String(L"Superbowl schedule"),
+        ref new String(L"World Cup E-ticket")
+    });
+}
+
+/// <summary>
+/// DragItemsStarting is called when the Drag and Drop operation starts
+/// We take advantage of it to set the content of the DataPackage
+/// as well as indicate which operations are supported
+/// </summary>
+/// <param name="sender"></param>
+/// <param name="e"></param>
+void Scenario4_MoveBetweenListView::ListView_DragItemsStarting(Platform::Object^ sender, Windows::UI::Xaml::Controls::DragItemsStartingEventArgs^ e)
+{
+	// Prepare a string with one dragged item per line
+	// Set the content of the DataPackage
+	if (e->Items->Size > 0)
+	{
+		e->Data->SetText(dynamic_cast<String^>(e->Items->GetAt(0)));
+		// As we want our Reference list to say intact, we only allow Move
+		e->Data->RequestedOperation = DataPackageOperation::Move;
+	}
+}
+
+/// <summary>
+/// DragOver is called when the dragged pointer moves over a UIElement with AllowDrop=True
+/// We need to return an AcceptedOperation != None in either DragOver or DragEnter
+/// </summary>
+/// <param name="sender"></param>
+/// <param name="e"></param>
+void Scenario4_MoveBetweenListView::ListView_DragOver(Platform::Object^ sender, Windows::UI::Xaml::DragEventArgs^ e)
+{
+    // Our list only accepts text
+    e->AcceptedOperation = (e->DataView->Contains(StandardDataFormats::Text)) ? DataPackageOperation::Move : DataPackageOperation::None;
+}
+
+/// <summary>
+/// We need to return the effective operation from Drop
+/// This is not important for our source ListView, but it might be if the user
+/// drags text from another source
+/// </summary>
+/// <param name="sender"></param>
+/// <param name="e"></param>
+void Scenario4_MoveBetweenListView::ListView_Drop(Platform::Object^ sender, Windows::UI::Xaml::DragEventArgs^ e)
+{
+    // This test is in theory not needed as we returned DataPackageOperation.None if
+    // the DataPackage did not contained text. However, it is always better if each
+    // method is robust by itself
+    if (e->DataView->Contains(StandardDataFormats::Text))
+    {
+        // We need to take a Deferral as we won't be able to confirm the end
+        // of the operation synchronously
+        auto def = e->GetDeferral();
+        create_task(e->DataView->GetTextAsync()).then([def, this, sender, e](String^ s)
+        {
+			// Get the lists we need to work with.
+			auto sourceList = (sender->Equals(TargetListView) ? _source : _target);
+			auto targetList = (sender->Equals(TargetListView) ? _target : _source);
+
+			// Remove item from other list
+			unsigned j;
+			if (sourceList->IndexOf(s, &j))
+			{
+				sourceList->RemoveAt(j);
+			}
+
+			// First we need to get the position in the List to drop to
+			auto listview = dynamic_cast<ListView^>(sender);
+			int index = -1;
+
+			// Determine which items in the list our pointer is inbetween.
+			for (int i = 0; i < listview->Items->Size; i++)
+			{
+				auto item = dynamic_cast<ListViewItem^>(listview->ContainerFromIndex(i));
+
+				auto p = e->GetPosition(item);
+
+				if (p.Y - item->ActualHeight < 0)
+				{
+					index = i;
+					break;
+				}
+			}
+
+			if (index < 0)
+			{
+				// We didn't find a transition point, so we're at the end of the list
+				targetList->Append(s);
+			}
+			else if (index < listview->Items->Size)
+			{
+				// Otherwise, insert at the provided index.
+				targetList->InsertAt(index, s);
+			}
+
+            e->AcceptedOperation = DataPackageOperation::Copy;
+            def->Complete();
+        });
+    }
+}

--- a/Samples/XamlDragAndDrop/cpp/Scenario4_MoveBetweenListView.xaml.h
+++ b/Samples/XamlDragAndDrop/cpp/Scenario4_MoveBetweenListView.xaml.h
@@ -1,0 +1,38 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+#pragma once
+
+#include "Scenario4_MoveBetweenListView.g.h"
+#include "MainPage.xaml.h"
+
+namespace SDKTemplate
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    [Windows::Foundation::Metadata::WebHostHidden]
+    public ref class Scenario4_MoveBetweenListView sealed
+    {
+    public:
+        Scenario4_MoveBetweenListView();
+    private:
+        MainPage^ rootPage;
+
+        Platform::Collections::Vector<Platform::String^>^ GetSampleData();
+        Platform::Collections::Vector<Platform::String^>^ _source;
+        Platform::Collections::Vector<Platform::String^>^ _target;
+
+        void ListView_DragItemsStarting(Platform::Object^ sender, Windows::UI::Xaml::Controls::DragItemsStartingEventArgs^ e);
+        void ListView_DragOver(Platform::Object^ sender, Windows::UI::Xaml::DragEventArgs^ e);
+        void ListView_Drop(Platform::Object^ sender, Windows::UI::Xaml::DragEventArgs^ e);
+    };
+}

--- a/Samples/XamlDragAndDrop/cs/DragAndDropSampleManaged.csproj
+++ b/Samples/XamlDragAndDrop/cs/DragAndDropSampleManaged.csproj
@@ -99,6 +99,9 @@
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="SampleConfiguration.cs" />
+    <Compile Include="Scenario4_MoveBetweenListView.xaml.cs">
+      <DependentUpon>Scenario4_MoveBetweenListView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Scenario1_ListView.xaml.cs">
       <DependentUpon>Scenario1_ListView.xaml</DependentUpon>
     </Compile>
@@ -122,6 +125,10 @@
     </ApplicationDefinition>
     <Page Include="..\..\..\SharedContent\cs\MainPage.xaml">
       <Link>MainPage.xaml</Link>
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Scenario4_MoveBetweenListView.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/Samples/XamlDragAndDrop/cs/SampleConfiguration.cs
+++ b/Samples/XamlDragAndDrop/cs/SampleConfiguration.cs
@@ -24,7 +24,8 @@ namespace SDKTemplate
         {
             new Scenario() { Title="ListView Drag and Drop and Reorder", ClassType=typeof(Scenario1_ListView)},
             new Scenario() { Title="Drag UI Customization", ClassType=typeof(Scenario2_DragUICustomization)},
-            new Scenario() { Title="StartDragAsync", ClassType=typeof(Scenario3_StartDragAsync)}
+            new Scenario() { Title="StartDragAsync", ClassType=typeof(Scenario3_StartDragAsync)},
+            new Scenario() { Title="Move Between ListViews", ClassType=typeof(Scenario4_MoveBetweenListView)}
         };
     }
 

--- a/Samples/XamlDragAndDrop/cs/Scenario4_MoveBetweenListView.xaml
+++ b/Samples/XamlDragAndDrop/cs/Scenario4_MoveBetweenListView.xaml
@@ -1,0 +1,71 @@
+<!--
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+-->
+<Page
+    x:Class="DragAndDropSampleManaged.Scenario4_MoveBetweenListView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:DragAndDropSampleManaged"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+        <StackPanel Margin="0,0,0,10" Grid.ColumnSpan="2">
+            <TextBlock Text="Description:" Style="{StaticResource SampleHeaderTextStyle}"/>
+            <TextBlock Style="{StaticResource ScenarioDescriptionTextStyle}" TextWrapping="Wrap" Text="This scenario illustrates how to use ListView's Drag and Drop to reorder single items while maintaining the requested position."/>
+        </StackPanel>
+
+        <TextBlock Grid.Row="1" Margin="8,4"
+                    VerticalAlignment="Bottom"
+                    Text="All Items"/>
+        <ListView x:Name="SourceListView"
+                    Grid.Row="2" Margin="8,4"
+                    AllowDrop="True" CanReorderItems="True" CanDragItems="True"
+                    DragOver="ListView_DragOver"
+                    Drop="ListView_Drop"
+                    DragItemsStarting="ListView_DragItemsStarting">
+            <ListView.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <!-- Need to use StackPanel to get insertion indicies -->
+                    <StackPanel/>
+                </ItemsPanelTemplate>
+            </ListView.ItemsPanel>
+        </ListView>
+        <TextBlock Grid.Row="1" Grid.Column="1" Margin="8,4"
+                    VerticalAlignment="Bottom"
+                    Text="Selection"/>
+        <ListView x:Name="TargetListView"
+                    Grid.Row="2" Grid.Column="1" Margin="8,4"
+                    AllowDrop="True" CanReorderItems="True" CanDragItems="True"
+                    DragOver="ListView_DragOver"
+                    Drop="ListView_Drop"
+                    DragItemsStarting="ListView_DragItemsStarting">
+            <ListView.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <!-- Need to use StackPanel to get insertion indicies -->
+                    <StackPanel/>
+                </ItemsPanelTemplate>
+            </ListView.ItemsPanel>
+        </ListView>
+    </Grid>
+</Page>

--- a/Samples/XamlDragAndDrop/cs/Scenario4_MoveBetweenListView.xaml
+++ b/Samples/XamlDragAndDrop/cs/Scenario4_MoveBetweenListView.xaml
@@ -43,14 +43,7 @@
                     AllowDrop="True" CanReorderItems="True" CanDragItems="True"
                     DragOver="ListView_DragOver"
                     Drop="ListView_Drop"
-                    DragItemsStarting="ListView_DragItemsStarting">
-            <ListView.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <!-- Need to use StackPanel to get insertion indicies -->
-                    <StackPanel/>
-                </ItemsPanelTemplate>
-            </ListView.ItemsPanel>
-        </ListView>
+                    DragItemsStarting="ListView_DragItemsStarting"/>
         <TextBlock Grid.Row="1" Grid.Column="1" Margin="8,4"
                     VerticalAlignment="Bottom"
                     Text="Selection"/>
@@ -59,13 +52,6 @@
                     AllowDrop="True" CanReorderItems="True" CanDragItems="True"
                     DragOver="ListView_DragOver"
                     Drop="ListView_Drop"
-                    DragItemsStarting="ListView_DragItemsStarting">
-            <ListView.ItemsPanel>
-                <ItemsPanelTemplate>
-                    <!-- Need to use StackPanel to get insertion indicies -->
-                    <StackPanel/>
-                </ItemsPanelTemplate>
-            </ListView.ItemsPanel>
-        </ListView>
+                    DragItemsStarting="ListView_DragItemsStarting"/>
     </Grid>
 </Page>

--- a/Samples/XamlDragAndDrop/cs/Scenario4_MoveBetweenListView.xaml.cs
+++ b/Samples/XamlDragAndDrop/cs/Scenario4_MoveBetweenListView.xaml.cs
@@ -1,0 +1,150 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// This code is licensed under the MIT License (MIT).
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+using SDKTemplate;
+using System;
+using System.Collections.ObjectModel;
+using Windows.ApplicationModel.DataTransfer;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace DragAndDropSampleManaged
+{
+    /// <summary>
+    /// This sample shows how to drag a single item between listviews and maintain the user's desired location.
+    /// </summary>
+    public sealed partial class Scenario4_MoveBetweenListView : Page
+    {
+        private MainPage rootPage;
+
+        ObservableCollection<string> _source;
+        ObservableCollection<string> _target;
+        string _deletedItem;
+
+        public Scenario4_MoveBetweenListView()
+        {
+            this.InitializeComponent();
+
+            _source = GetSampleData();
+            _target = new ObservableCollection<string>();
+            SourceListView.ItemsSource = _source;
+            TargetListView.ItemsSource = _target;
+        }
+        private ObservableCollection<string> GetSampleData()
+        {
+            return new ObservableCollection<string>
+            {
+                "My Research Paper",
+                "Electricity Bill",
+                "My To-do list",
+                "TV sales receipt",
+                "Water Bill",
+                "Grocery List",
+                "Superbowl schedule",
+                "World Cup E-ticket"
+            };
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            rootPage = MainPage.Current;
+        }
+
+        /// <summary>
+        /// DragItemsStarting is called when the Drag and Drop operation starts
+        /// We take advantage of it to set the content of the DataPackage
+        /// as well as indicate which operations are supported
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void ListView_DragItemsStarting(object sender, DragItemsStartingEventArgs e)
+        {
+            // Prepare a string with one dragged item per line
+            // Set the content of the DataPackage
+            e.Data.SetText(e.Items.FirstOrDefault() as string);
+            // As we want our Reference list to mutate, we only allow Move
+            e.Data.RequestedOperation = DataPackageOperation.Move;
+        }
+
+        /// <summary>
+        /// DragOver is called when the dragged pointer moves over a UIElement with AllowDrop=True
+        /// We need to return an AcceptedOperation != None in either DragOver or DragEnter
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void ListView_DragOver(object sender, DragEventArgs e)
+        {
+            // Our list only accepts text
+            e.AcceptedOperation = (e.DataView.Contains(StandardDataFormats.Text)) ? DataPackageOperation.Move : DataPackageOperation.None;
+        }
+
+        /// <summary>
+        /// We need to return the effective operation from Drop
+        /// This is not important for our source ListView, but it might be if the user
+        /// drags text from another source
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private async void ListView_Drop(object sender, DragEventArgs e)
+        {
+            // This test is in theory not needed as we returned DataPackageOperation.None if
+            // the DataPackage did not contained text. However, it is always better if each
+            // method is robust by itself
+            if (e.DataView.Contains(StandardDataFormats.Text))
+            {
+                // We need to take a Deferral as we won't be able to confirm the end
+                // of the operation synchronously
+                var def = e.GetDeferral();
+                var text = await e.DataView.GetTextAsync();
+
+                // Get the lists we need to work with.
+                var sourceList = (sender == TargetListView ? _source : _target);
+                var targetList = (sender == TargetListView ? _target : _source);
+
+                // Remove item from other list
+                sourceList.Remove(text);
+
+                // Get position in List to drop to
+                var listview = sender as ListView;
+                var panel = listview.ItemsPanelRoot;
+                var point = e.GetPosition(panel);
+
+                // Use insertion panel interface (available on StackPanel) to help us.
+                if (panel is IInsertionPanel ipanel)
+                {
+                    ipanel.GetInsertionIndexes(point, out int aboveIndex, out int belowIndex);
+
+                    // Top of List
+                    if (aboveIndex == -1 && belowIndex >= 0)
+                    {
+                        targetList.Insert(0, text);
+                    }
+                    // Between two items
+                    else if (aboveIndex >= 0 && belowIndex >= 0)
+                    {
+                        targetList.Insert(aboveIndex, text);
+                    }
+                    // Bottom of List
+                    else if (aboveIndex >= 0 && belowIndex == -1)
+                    {
+                        targetList.Add(text);
+                    }
+                }
+
+                e.AcceptedOperation = DataPackageOperation.Move;
+                def.Complete();
+            }
+        }
+    }
+}

--- a/Samples/XamlDragAndDrop/cs/Scenario4_MoveBetweenListView.xaml.cs
+++ b/Samples/XamlDragAndDrop/cs/Scenario4_MoveBetweenListView.xaml.cs
@@ -30,7 +30,6 @@ namespace DragAndDropSampleManaged
 
         ObservableCollection<string> _source;
         ObservableCollection<string> _target;
-        string _deletedItem;
 
         public Scenario4_MoveBetweenListView()
         {


### PR DESCRIPTION
This is an additional sample to the XamlDragAndDrop example which shows how to drag between two ListViews in an application and *maintain the user's desired position*.

The later part was missing from the original samples and is non-trivial.  This examples provides a still straight-forward solution which works well in the majority of cases in combination with the platform animation.

Both C# and C++ solutions are provided here and behave the same.  I tested on 17763.