### PR TITLE
Updating Holographic samples to use a font supported by the HoloLens.

### DIFF
--- a/Samples/HolographicFaceTracking/cpp/Content/TextRenderer.cpp
+++ b/Samples/HolographicFaceTracking/cpp/Content/TextRenderer.cpp
@@ -122,7 +122,7 @@ concurrency::task<void> TextRenderer::CreateDeviceDependentResourcesAsync()
         // This is where we format the text that will be written on the render target.
         DX::ThrowIfFailed(
             m_deviceResources->GetDWriteFactory()->CreateTextFormat(
-                L"Consolas",
+                L"Segoe UI",
                 NULL,
                 DWRITE_FONT_WEIGHT_NORMAL,
                 DWRITE_FONT_STYLE_NORMAL,

--- a/Samples/HolographicTagAlong/cpp/Content/TextRenderer.cpp
+++ b/Samples/HolographicTagAlong/cpp/Content/TextRenderer.cpp
@@ -121,7 +121,7 @@ void TextRenderer::CreateDeviceDependentResources()
     // This is where we format the text that will be written on the render target.
     DX::ThrowIfFailed(
         m_deviceResources->GetDWriteFactory()->CreateTextFormat(
-            L"Consolas",
+            L"Segoe UI",
             NULL,
             DWRITE_FONT_WEIGHT_NORMAL,
             DWRITE_FONT_STYLE_NORMAL,


### PR DESCRIPTION
"Consolas" is used in these Holographic samples, but the font does not appear to be supported on the HoloLens (at least through DirectWrite). These samples end up displaying as the fallback/recommended font, which is "Segoe UI".