### PR TITLE
Add example of getting/reading Appointments to the Appointments sample 

### DIFF
--- a/Samples/Appointments/cs/Package.appxmanifest
+++ b/Samples/Appointments/cs/Package.appxmanifest
@@ -27,5 +27,6 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClient" />
+    <uap:Capability Name="appointments" />
   </Capabilities>
 </Package>

--- a/Samples/Appointments/cs/Scenario5_Show.xaml.cs
+++ b/Samples/Appointments/cs/Scenario5_Show.xaml.cs
@@ -13,6 +13,10 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 using System;
+using Windows.ApplicationModel.Appointments;
+using System.Linq;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 
 namespace SDKTemplate
 {
@@ -23,7 +27,41 @@ namespace SDKTemplate
         public Scenario5_Show()
         {
             this.InitializeComponent();
+            this.DataContext = this;
         }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+            var ignore = AppointmentGet();
+        }
+
+        private async Task AppointmentGet()
+        {
+            var dateToShow = DateTime.Now.AddDays(1);
+            var duration = TimeSpan.FromHours(24);
+
+            AppointmentStore calendar = await AppointmentManager.RequestStoreAsync(AppointmentStoreAccessType.AllCalendarsReadOnly);
+
+            // Specify which values to retrieve
+            FindAppointmentsOptions options = new FindAppointmentsOptions();
+            options.FetchProperties.Add(AppointmentProperties.Subject);
+            options.FetchProperties.Add(AppointmentProperties.StartTime);
+            options.FetchProperties.Add(AppointmentProperties.Duration);
+            options.FetchProperties.Add(AppointmentProperties.AllDay);
+            options.FetchProperties.Add(AppointmentProperties.Details);
+            options.FetchProperties.Add(AppointmentProperties.DetailsKind);
+
+            var iteratingAppointments = await calendar.FindAppointmentsAsync(dateToShow, duration, options);
+            var items = from a in iteratingAppointments select a;
+
+            await rootPage.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, 
+                () => { items.ToList().ForEach(a => this.appointments.Add(a)); }
+                );
+        }
+
+        private ObservableCollection<Appointment> appointments = new ObservableCollection<Appointment>();
+        public ObservableCollection<Appointment> Appointments => appointments;
 
         /// <summary>
         /// Show the default appointment provider at a point in time 24 hours from now.
@@ -33,7 +71,8 @@ namespace SDKTemplate
         private async void Show_Click(object sender, RoutedEventArgs e)
         {
             var dateToShow = DateTime.Now.AddDays(1);
-            var duration = TimeSpan.FromHours(1);
+            var duration = TimeSpan.FromHours(24);
+
             await Windows.ApplicationModel.Appointments.AppointmentManager.ShowTimeFrameAsync(dateToShow, duration);
             rootPage.NotifyUser("The default appointments provider should have appeared on screen.", NotifyType.StatusMessage);
         }

--- a/Samples/Appointments/shared/Scenario5_Show.xaml
+++ b/Samples/Appointments/shared/Scenario5_Show.xaml
@@ -25,7 +25,50 @@
                 <TextBlock Style="{StaticResource ScenarioDescriptionTextStyle}" TextWrapping="Wrap">
                     Shows the default appointments provider app at a particular time and date.
                 </TextBlock>
-                <Button x:Name="ShowTimeFrameButton" Content="Show 24 hours from now" Margin="0,10,0,0" Click="Show_Click"/>
+                <Button x:Name="ShowTimeFrameButton" Content="Show Calendar View of 24 hours from now" Margin="0,10,0,0" Click="Show_Click"/>
+
+                <TextBlock Padding="30" FontSize="30">List of Calendar events 24 hours from now</TextBlock>
+                <GridView ItemsSource="{Binding Appointments}"
+                  IsItemClickEnabled="True"
+                  IsSwipeEnabled="true"
+                  SelectionMode="Single">
+                    <GridView.HeaderTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="200"/>
+                                    <ColumnDefinition Width="300"/>
+                                    <ColumnDefinition Width="100"/>
+                                    <ColumnDefinition Width="100"/>
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Column="0" Text="Subject"/>
+                                <TextBlock Grid.Column="1" Text="StartTime"/>
+                                <TextBlock Grid.Column="2" Text="Duration"/>
+                                <TextBlock Grid.Column="3" Text="AllDay?"/>
+                            </Grid>
+                        </DataTemplate>  
+                    </GridView.HeaderTemplate>
+               
+                    <GridView.ItemTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="200"/>
+                                    <ColumnDefinition Width="300"/>
+                                    <ColumnDefinition Width="100"/>
+                                    <ColumnDefinition Width="100"/>
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Column="0" Text="{Binding Subject}"/>
+                                <TextBlock Grid.Column="1" Text="{Binding StartTime}"/>
+                                <TextBlock Grid.Column="2" Text="{Binding Duration}"/>
+                                <TextBlock Grid.Column="3" Text="{Binding AllDay}"/>
+                            </Grid>
+                        </DataTemplate>
+                    </GridView.ItemTemplate>
+                </GridView>
+
             </StackPanel>
         </Grid>
     </Grid>


### PR DESCRIPTION
Add example of getting Appointments to the Appointments sample (currently missing critical scenario)
In this sample is the ability to CUD, but not CRUD.   Adding, Updating, and Deleting are included but not reading events and listing them. 
This change adds this to the "Show" scenario.

FYI: added missing capability "Appointments" which requires user to accept dialog popup.