### PR TITLE
Fix race condition and logic bugs in HolographicSpatialMapping sample

### DIFF
--- a/Samples/HolographicSpatialMapping/cpp/Content/SurfaceMesh.h
+++ b/Samples/HolographicSpatialMapping/cpp/Content/SurfaceMesh.h
@@ -41,7 +41,7 @@ namespace WindowsHolographicCodeSamples
 
         void Draw(ID3D11Device* device, ID3D11DeviceContext* context, bool usingVprtShaders, bool isStereo);
 
-        void CreateVertexResources(ID3D11Device* device);
+        void CreateVertexResources(ID3D11Device* device, Windows::Perception::Spatial::Surfaces::SpatialSurfaceMesh^ surfaceMesh);
         void CreateDeviceDependentResources(ID3D11Device* device);
         void ReleaseVertexResources();
         void ReleaseDeviceDependentResources();


### PR DESCRIPTION
This change fixes a race condition between UpdateSurface and CreateVertexResources in the HolographicSpatialMapping sample by explicitly plumbing the pending SpatialSurfaceMesh object to the update thread instead of directly referencing m_surfaceMesh. It also fixes a small logic bug which would cause a surface to be dropped permanently if it ever failed to be located on a given frame.