### PR TITLE
Fix capability for the Wi-Fi Direct sample

### DIFF
--- a/Samples/WiFiDirect/cpp/Package.appxmanifest
+++ b/Samples/WiFiDirect/cpp/Package.appxmanifest
@@ -48,7 +48,7 @@
     </Applications>
 
     <Capabilities>
-        <Capability Name="internetClient" />
+        <Capability Name="internetClientServer" />
         <DeviceCapability Name="proximity" />
     </Capabilities>
 </Package>

--- a/Samples/WiFiDirect/cs/Package.appxmanifest
+++ b/Samples/WiFiDirect/cs/Package.appxmanifest
@@ -48,7 +48,7 @@
     </Applications>
 
     <Capabilities>
-        <Capability Name="internetClient" />
+        <Capability Name="internetClientServer" />
         <DeviceCapability Name="proximity" />
     </Capabilities>
 </Package>

--- a/Samples/WiFiDirect/js/package.appxmanifest
+++ b/Samples/WiFiDirect/js/package.appxmanifest
@@ -47,7 +47,7 @@
   </Applications>
 
   <Capabilities>
-    <Capability Name="internetClient" />
+    <Capability Name="internetClientServer" />
     <DeviceCapability Name="proximity" />
   </Capabilities>
 


### PR DESCRIPTION
As was reported here https://github.com/microsoft/Windows-universal-samples/issues/1081, the sample should declare the internetClientServer capability, as there are scenarios where it is listening for inbound connections.