### PR TITLE
Restoring version of .NET Core package reference per feedback

### DIFF
--- a/Samples/BackgroundActivation/cs/BackgroundActivation.csproj
+++ b/Samples/BackgroundActivation/cs/BackgroundActivation.csproj
@@ -208,7 +208,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.8</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">


### PR DESCRIPTION
Raymond C. suggested that for now samples should continue to reference the 5.0 package version. This undoes the update from my previous commit to restore the original version number.