### PR TITLE
Fixed protocol navigation

### DIFF
--- a/Samples/UserActivity/cs/SampleConfiguration.cs
+++ b/Samples/UserActivity/cs/SampleConfiguration.cs
@@ -30,7 +30,10 @@ namespace SDKTemplate
 
         public void NavigateToScenarioWithParameter(Scenario scenario, object parameter)
         {
-            ScenarioControl.SelectedItem = scenario;
+            const String _scenario= "Scenario";
+            var i = scenario.ClassType.ToString().IndexOf(_scenario) + _scenario.Length;
+            var index = scenario.ClassType.ToString()[i].ToString();
+            ScenarioControl.SelectedIndex = int.Parse(index) - 1;
             ScenarioFrame.Navigate(scenario.ClassType, parameter);
         }
     }
@@ -66,7 +69,8 @@ namespace SDKTemplate
                 var protocolArgs = (IProtocolActivatedEventArgs)e;
                 foreach (var scenario in mainPage.Scenarios)
                 {
-                    if (scenario.ClassType.Name == protocolArgs.Uri.Query)
+                    var query = (protocolArgs.Uri.Query[0] == '?') ? protocolArgs.Uri.Query.Substring(1) : protocolArgs.Uri.Query;
+                    if (scenario.ClassType.Name == query)
                     {
                         destinationScenario = scenario;
                     }


### PR DESCRIPTION
Protocol navigation failed to navigate to anything but first scenario for two reasons;
1) This always fails: if (scenario.ClassType.Name == protocolArgs.Uri.Query), since protocolArgs.Uri.Query has the leading '?'.
2) This assignment does not change the selected item: ScenarioControl.SelectedItem = scenario;
Changed to setting the selected index, this works.