### PR TITLE
docs: Broken link to CameraFrames sample

### DIFF
--- a/Samples/HolographicFaceTracking/README.md
+++ b/Samples/HolographicFaceTracking/README.md
@@ -84,7 +84,7 @@ Microsoft Visual Studio and the Microsoft HoloLens Emulator, go to
 
 [BasicFaceTracking](/Samples/BasicFaceTracking)
 
-[CameraFrames](/Sample/CameraFrames)
+[CameraFrames](/Samples/CameraFrames)
 
 ### Reference
 


### PR DESCRIPTION
CameraFrames sample link was broken and resulted in 404 error.


Incorrect link has the form:
```javascript
 /Sample/CameraFrames
```
Corrected link has the form:

```javascript
 /Samples/CameraFrames
```

Note the addition of **s** to the 'Sample' directory.