### PR TITLE
Add missing namespace in C++/WinRT BarcodeScanner

### DIFF
--- a/Samples/BarcodeScanner/cppwinrt/DataHelpers.cpp
+++ b/Samples/BarcodeScanner/cppwinrt/DataHelpers.cpp
@@ -79,6 +79,6 @@ winrt::hstring GetDataLabelString(winrt::IBuffer const& data, uint32_t scanDataT
     {
         // Some other symbologies (typically 2-D symbologies) contain binary data that
         //  should not be converted to text.
-        return hstring{ L"Decoded data unavailable. Raw label data: " + GetDataString(data) };
+        return winrt::hstring{ L"Decoded data unavailable. Raw label data: " + GetDataString(data) };
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Note that nontrivial changes will need to be reviewed by the feature team and will take time. -->

## Description

Name of sample: BarcodeScanner

<!-- Describe your changes in detail -->
<!-- If this change fixes an open issue, please link to the issue here. -->
The C++/WinRT variant of the BarcodeScanner sample would not compile successfully until `hstring` was prefixed with `winrt::` in DataHelpers.cpp.

## Testing
Ran in Visual Studio 2019.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran. -->

## Type of change
<!-- Select all that apply. -->
- [X] Bug fix
- [ ] New feature
- [ ] Porting to new language

## Supported platforms
Minimum OS version: 17763

<!-- Select all that apply. -->
- [X] All UWP platforms
- [ ] Desktop
- [ ] Holographic
- [ ] IoT
- [ ] Xbox
- [ ] 10X

## Supported languages
<!-- Select all that apply. -->
<!-- If the sample is available in more than one language, make sure your change applies to all versions. -->
<!-- C++/CX, JavaScript, and Visual Basic samples are no longer being maintained. -->
<!-- They are archived when the underlying sample changes. C++/CX samples are ported to C++/WinRT. -->
- [ ] C#
- [X] C++/WinRT

<!--## Additional remarks-->
<!-- Optional. -->
