### PR TITLE
updating Geolocationsample app with IsRemoteSource flag

### DIFF
--- a/Samples/Geolocation/cpp/GeolocationCPP/Scenario1_TrackPosition.xaml
+++ b/Samples/Geolocation/cpp/GeolocationCPP/Scenario1_TrackPosition.xaml
@@ -28,15 +28,18 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="0" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Status: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="1" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Latitude: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="2" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Longitude: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="3" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Accuracy: " />
+                <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="4" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="IsRemoteSource: " />
                 <TextBlock x:Name="ScenarioOutput_Status" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Unknown" />
                 <TextBlock x:Name="ScenarioOutput_Latitude" TextWrapping="Wrap" Grid.Row="1" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Longitude" TextWrapping="Wrap" Grid.Row="2" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Accuracy" TextWrapping="Wrap" Grid.Row="3" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
+                <TextBlock x:Name="ScenarioOutput_IsRemoteSource" TextWrapping="Wrap" Grid.Row="4" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
             </Grid>
             <TextBlock TextWrapping="Wrap" x:Name="LocationDisabledMessage" Margin="0,10,0,0" FontStyle="Italic" Visibility="Collapsed">
                 <Run Text="Application is not able to get location data. Go to " />

--- a/Samples/Geolocation/cpp/GeolocationCPP/Scenario1_TrackPosition.xaml.cpp
+++ b/Samples/Geolocation/cpp/GeolocationCPP/Scenario1_TrackPosition.xaml.cpp
@@ -135,6 +135,7 @@ void Scenario1::OnPositionChanged(Geolocator^ sender, PositionChangedEventArgs^ 
         ScenarioOutput_Latitude->Text = coordinate->Point->Position.Latitude.ToString();
         ScenarioOutput_Longitude->Text = coordinate->Point->Position.Longitude.ToString();
         ScenarioOutput_Accuracy->Text = coordinate->Accuracy.ToString();
+        ScenarioOutput_IsRemoteSource->Text = coordinate->IsRemoteSource.ToString();
     },
         CallbackContext::Any
         )
@@ -178,6 +179,7 @@ void Scenario1::OnStatusChanged(Geolocator^ sender, StatusChangedEventArgs^ e)
             ScenarioOutput_Latitude->Text = "No data";
             ScenarioOutput_Longitude->Text = "No data";
             ScenarioOutput_Accuracy->Text = "No data";
+            ScenarioOutput_IsRemoteSource->Text = "No data";
             break;
 
         case Windows::Devices::Geolocation::PositionStatus::NotInitialized:

--- a/Samples/Geolocation/cpp/GeolocationCPP/Scenario2_GetPosition.xaml
+++ b/Samples/Geolocation/cpp/GeolocationCPP/Scenario2_GetPosition.xaml
@@ -46,11 +46,13 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="0" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Latitude: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="1" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Longitude: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="2" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Accuracy: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="3" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Source: " />
+                <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="4" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="IsRemoteSource: " />
                 <TextBlock x:Name="Label_DilutionOfPrecision" Margin="0,0,10,0" Visibility="{Binding Visibility, ElementName=ScenarioOutput_PosPrecision}"  TextWrapping="Wrap" Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Dilution Of Precision (DOP): " />
                 <TextBlock x:Name="Label_PosPrecision" Margin="20,0,10,0" Visibility="{Binding Visibility, ElementName=ScenarioOutput_PosPrecision}"  TextWrapping="Wrap" Grid.Row="6" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Position DOP: " />
                 <TextBlock x:Name="Label_HorzPrecision" Margin="20,0,10,0" Visibility="{Binding Visibility, ElementName=ScenarioOutput_HorzPrecision}" TextWrapping="Wrap" Grid.Row="7" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Horizontal DOP: " />
@@ -59,6 +61,7 @@
                 <TextBlock x:Name="ScenarioOutput_Longitude" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="1" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Accuracy" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="2" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Source" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="3" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
+                <TextBlock x:Name="ScenarioOutput_IsRemoteSource" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="4" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_PosPrecision" Margin="0,0,10,0" Visibility="Collapsed" TextWrapping="Wrap" Grid.Row="6" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_HorzPrecision" Margin="0,0,10,0" Visibility="Collapsed" TextWrapping="Wrap" Grid.Row="7" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_VertPrecision" Margin="0,0,10,0" Visibility="Collapsed" TextWrapping="Wrap" Grid.Row="8" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />

--- a/Samples/Geolocation/cpp/GeolocationCPP/Scenario2_GetPosition.xaml.cpp
+++ b/Samples/Geolocation/cpp/GeolocationCPP/Scenario2_GetPosition.xaml.cpp
@@ -152,6 +152,7 @@ void Scenario2::UpdateLocationData(Windows::Devices::Geolocation::Geoposition^ p
         ScenarioOutput_Latitude->Text = "No data";
         ScenarioOutput_Longitude->Text = "No data";
         ScenarioOutput_Accuracy->Text = "No data";
+        ScenarioOutput_IsRemoteSource->Text = "No data";
     }
     else
     {
@@ -159,6 +160,7 @@ void Scenario2::UpdateLocationData(Windows::Devices::Geolocation::Geoposition^ p
         ScenarioOutput_Longitude->Text = position->Coordinate->Point->Position.Longitude.ToString();
         ScenarioOutput_Accuracy->Text = position->Coordinate->Accuracy.ToString();
         ScenarioOutput_Source->Text = position->Coordinate->PositionSource.ToString();
+        ScenarioOutput_IsRemoteSource->Text = position->Coordinate->IsRemoteSource.ToString();
         
         if (position->Coordinate->PositionSource == PositionSource::Satellite)
         {

--- a/Samples/Geolocation/cpp/GeolocationCPP/Scenario6_GetLastVisit.xaml
+++ b/Samples/Geolocation/cpp/GeolocationCPP/Scenario6_GetLastVisit.xaml
@@ -43,17 +43,20 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="0" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="State change: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="1" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Timestamp: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="2" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Latitude: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="3" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Longitude: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="4" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Accuracy: " />
+                <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="5" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Source: " />
                 <TextBlock x:Name="ScenarioOutput_VisitStateChange" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Timestamp" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="1" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Latitude" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="2" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Longitude" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="3" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Accuracy" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="4" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
+                <TextBlock x:Name="ScenarioOutput_IsRemoteSource" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="5" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
             </Grid>
             <TextBlock TextWrapping="Wrap" x:Name="LocationDisabledMessage" Margin="0,10,0,0" FontStyle="Italic" Visibility="Collapsed">
               <Run Text="Application is not able to get location data. Go to " />

--- a/Samples/Geolocation/cpp/GeolocationCPP/Scenario6_GetLastVisit.xaml.cpp
+++ b/Samples/Geolocation/cpp/GeolocationCPP/Scenario6_GetLastVisit.xaml.cpp
@@ -89,6 +89,7 @@ void Scenario6::UpdateLastVisit(Geovisit^ visit)
         ScenarioOutput_Latitude->Text = "No data";
         ScenarioOutput_Longitude->Text = "No data";
         ScenarioOutput_Accuracy->Text = "No data";
+        ScenarioOutput_IsRemoteSource->Text = "No data";
         ScenarioOutput_Timestamp->Text = "No data";
         ScenarioOutput_VisitStateChange->Text = "No data";
     }
@@ -106,12 +107,14 @@ void Scenario6::UpdateLastVisit(Geovisit^ visit)
             ScenarioOutput_Latitude->Text = "No data";
             ScenarioOutput_Longitude->Text = "No data";
             ScenarioOutput_Accuracy->Text = "No data";
+            ScenarioOutput_IsRemoteSource->Text = "No data";
         }
         else
         {
             ScenarioOutput_Latitude->Text = visit->Position->Coordinate->Point->Position.Latitude.ToString();
             ScenarioOutput_Longitude->Text = visit->Position->Coordinate->Point->Position.Longitude.ToString();
             ScenarioOutput_Accuracy->Text = visit->Position->Coordinate->Accuracy.ToString();
+            ScenarioOutput_IsRemoteSource->Text = visit->Position->Coordinate->IsRemoteSource.ToString();
         }
     }
 }

--- a/Samples/Geolocation/cpp/GeolocationCPP/Scenario7_ForegroundVisits.xaml
+++ b/Samples/Geolocation/cpp/GeolocationCPP/Scenario7_ForegroundVisits.xaml
@@ -30,17 +30,20 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="0" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="State change: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="1" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Timestamp: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="2" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Latitude: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="3" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Longitude: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="4" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Accuracy: " />
+                <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="5" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="IsRemoteSource: " />
                 <TextBlock x:Name="ScenarioOutput_VisitStateChange" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Timestamp" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="1" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Latitude" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="2" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Longitude" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="3" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Accuracy" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="4" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
+                <TextBlock x:Name="ScenarioOutput_IsRemoteSource" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="5" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
             </Grid>
             <TextBlock TextWrapping="Wrap" x:Name="LocationDisabledMessage" Margin="0,10,0,0" FontStyle="Italic" Visibility="Collapsed">
                 <Run Text="Application is not able to get location data. Go to " />

--- a/Samples/Geolocation/cpp/GeolocationCPP/Scenario7_ForegroundVisits.xaml.cpp
+++ b/Samples/Geolocation/cpp/GeolocationCPP/Scenario7_ForegroundVisits.xaml.cpp
@@ -151,11 +151,13 @@ void Scenario7::UpdateVisitData(Geovisit^ visit)
         ScenarioOutput_Latitude->Text = "No data";
         ScenarioOutput_Longitude->Text = "No data";
         ScenarioOutput_Accuracy->Text = "No data";
+        ScenarioOutput_IsRemoteSource->Text = "No data";
     }
     else
     {
         ScenarioOutput_Latitude->Text = visit->Position->Coordinate->Point->Position.Latitude.ToString();
         ScenarioOutput_Longitude->Text = visit->Position->Coordinate->Point->Position.Longitude.ToString();
         ScenarioOutput_Accuracy->Text = visit->Position->Coordinate->Accuracy.ToString();
+        ScenarioOutput_IsRemoteSource->Text = visit->Position->Coordinate->IsRemoteSource.ToString();
     }
 }

--- a/Samples/Geolocation/cs/GeolocationCS/Scenario1_TrackPosition.xaml
+++ b/Samples/Geolocation/cs/GeolocationCS/Scenario1_TrackPosition.xaml
@@ -28,15 +28,18 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="0" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Status: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="1" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Latitude: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="2" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Longitude: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="3" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Accuracy: " />
+                <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="4" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="IsRemoteSource: " />
                 <TextBlock x:Name="ScenarioOutput_Status" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Unknown" />
                 <TextBlock x:Name="ScenarioOutput_Latitude" TextWrapping="Wrap" Grid.Row="1" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Longitude" TextWrapping="Wrap" Grid.Row="2" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Accuracy" TextWrapping="Wrap" Grid.Row="3" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
+                <TextBlock x:Name="ScenarioOutput_IsRemoteSource" TextWrapping="Wrap" Grid.Row="4" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
             </Grid>
             <TextBlock TextWrapping="Wrap" x:Name="LocationDisabledMessage" Margin="0,10,0,0" FontStyle="Italic" Visibility="Collapsed">
                 <Run Text="Application is not able to get location data. Go to " />

--- a/Samples/Geolocation/cs/GeolocationCS/Scenario1_TrackPosition.xaml.cs
+++ b/Samples/Geolocation/cs/GeolocationCS/Scenario1_TrackPosition.xaml.cs
@@ -219,12 +219,14 @@ namespace GeolocationCS
                 ScenarioOutput_Latitude.Text = "No data";
                 ScenarioOutput_Longitude.Text = "No data";
                 ScenarioOutput_Accuracy.Text = "No data";
+                ScenarioOutput_IsRemoteSource.Text = "No data";
             }
             else
             {
                 ScenarioOutput_Latitude.Text = position.Coordinate.Point.Position.Latitude.ToString();
                 ScenarioOutput_Longitude.Text = position.Coordinate.Point.Position.Longitude.ToString();
                 ScenarioOutput_Accuracy.Text = position.Coordinate.Accuracy.ToString();
+                ScenarioOutput_IsRemoteSource.Text = position.Coordinate.IsRemoteSource.ToString();
             }
         }
     }

--- a/Samples/Geolocation/cs/GeolocationCS/Scenario2_GetPosition.xaml
+++ b/Samples/Geolocation/cs/GeolocationCS/Scenario2_GetPosition.xaml
@@ -46,11 +46,13 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="0" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Latitude: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="1" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Longitude: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="2" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Accuracy: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="3" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Source: " />
+                <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="4" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="IsRemoteSource: " />
                 <TextBlock x:Name="Label_DilutionOfPrecision" Margin="0,0,10,0" Visibility="{Binding Visibility, ElementName=ScenarioOutput_PosPrecision}"  TextWrapping="Wrap" Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Dilution Of Precision (DOP): " />
                 <TextBlock x:Name="Label_PosPrecision" Margin="20,0,10,0" Visibility="{Binding Visibility, ElementName=ScenarioOutput_PosPrecision}"  TextWrapping="Wrap" Grid.Row="6" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Position DOP: " />
                 <TextBlock x:Name="Label_HorzPrecision" Margin="20,0,10,0" Visibility="{Binding Visibility, ElementName=ScenarioOutput_HorzPrecision}" TextWrapping="Wrap" Grid.Row="7" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Horizontal DOP: " />
@@ -59,6 +61,7 @@
                 <TextBlock x:Name="ScenarioOutput_Longitude" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="1" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Accuracy" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="2" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Source" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="3" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
+                <TextBlock x:Name="ScenarioOutput_IsRemoteSource" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="4" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_PosPrecision" Margin="0,0,10,0" Visibility="Collapsed" TextWrapping="Wrap" Grid.Row="6" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_HorzPrecision" Margin="0,0,10,0" Visibility="Collapsed" TextWrapping="Wrap" Grid.Row="7" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_VertPrecision" Margin="0,0,10,0" Visibility="Collapsed" TextWrapping="Wrap" Grid.Row="8" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />

--- a/Samples/Geolocation/cs/GeolocationCS/Scenario2_GetPosition.xaml.cs
+++ b/Samples/Geolocation/cs/GeolocationCS/Scenario2_GetPosition.xaml.cs
@@ -186,6 +186,7 @@ namespace GeolocationCS
                 ScenarioOutput_Longitude.Text = "No data";
                 ScenarioOutput_Accuracy.Text = "No data";
                 ScenarioOutput_Source.Text = "No data";
+                ScenarioOutput_IsRemoteSource.Text = "No data";
                 ShowSatalliteData(false);
             }
             else
@@ -194,7 +195,8 @@ namespace GeolocationCS
                 ScenarioOutput_Longitude.Text = position.Coordinate.Point.Position.Longitude.ToString();
                 ScenarioOutput_Accuracy.Text = position.Coordinate.Accuracy.ToString();
                 ScenarioOutput_Source.Text = position.Coordinate.PositionSource.ToString();
-                
+                ScenarioOutput_IsRemoteSource.Text = position.Coordinate.IsRemoteSource.ToString();
+
                 if (position.Coordinate.PositionSource == PositionSource.Satellite)
                 {
                     // Show labels and satellite data when available

--- a/Samples/Geolocation/cs/GeolocationCS/Scenario6_GetLastVisit.xaml
+++ b/Samples/Geolocation/cs/GeolocationCS/Scenario6_GetLastVisit.xaml
@@ -43,17 +43,20 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="0" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="State change: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="1" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Timestamp: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="2" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Latitude: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="3" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Longitude: " />
                 <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="4" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Accuracy: " />
+                <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="5" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="IsRemoteSource: " />
                 <TextBlock x:Name="ScenarioOutput_VisitStateChange" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Timestamp" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="1" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Latitude" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="2" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Longitude" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="3" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
                 <TextBlock x:Name="ScenarioOutput_Accuracy" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="4" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
+                <TextBlock x:Name="ScenarioOutput_IsRemoteSource" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="5" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
             </Grid>
             <TextBlock TextWrapping="Wrap" x:Name="LocationDisabledMessage" Margin="0,10,0,0" FontStyle="Italic" Visibility="Collapsed">
               <Run Text="Application is not able to get location data. Go to " />

--- a/Samples/Geolocation/cs/GeolocationCS/Scenario6_GetLastVisit.xaml.cs
+++ b/Samples/Geolocation/cs/GeolocationCS/Scenario6_GetLastVisit.xaml.cs
@@ -105,12 +105,14 @@ namespace GeolocationCS
                     ScenarioOutput_Latitude.Text = "No data";
                     ScenarioOutput_Longitude.Text = "No data";
                     ScenarioOutput_Accuracy.Text = "No data";
+                    ScenarioOutput_IsRemoteSource.Text = "No data";
                 }
                 else
                 {
                     ScenarioOutput_Latitude.Text = visit.Position.Coordinate.Point.Position.Latitude.ToString();
                     ScenarioOutput_Longitude.Text = visit.Position.Coordinate.Point.Position.Longitude.ToString();
                     ScenarioOutput_Accuracy.Text = visit.Position.Coordinate.Accuracy.ToString();
+                    ScenarioOutput_IsRemoteSource.Text = visit.Position.Coordinate.IsRemoteSource.ToString();
                 }
             }
         }

--- a/Samples/Geolocation/cs/GeolocationCS/Scenario7_ForegroundVisits.xaml
+++ b/Samples/Geolocation/cs/GeolocationCS/Scenario7_ForegroundVisits.xaml
@@ -30,17 +30,20 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
               <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="0" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="State change: " />
               <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="1" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Timestamp: " />
               <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="2" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Latitude: " />
               <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="3" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Longitude: " />
               <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="4" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="Accuracy: " />
+              <TextBlock TextWrapping="Wrap" Margin="0,0,10,0" Grid.Row="5" Grid.Column="0" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="IsRemoteSource: " />
               <TextBlock x:Name="ScenarioOutput_VisitStateChange" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
               <TextBlock x:Name="ScenarioOutput_Timestamp" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="1" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
               <TextBlock x:Name="ScenarioOutput_Latitude" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="2" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
               <TextBlock x:Name="ScenarioOutput_Longitude" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="3" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
               <TextBlock x:Name="ScenarioOutput_Accuracy" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="4" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
+              <TextBlock x:Name="ScenarioOutput_IsRemoteSource" Margin="0,0,10,0" TextWrapping="Wrap" Grid.Row="5" Grid.Column="1" Style="{StaticResource BasicTextStyle}" HorizontalAlignment="Left" Text="No data" />
             </Grid>
             <TextBlock TextWrapping="Wrap" x:Name="LocationDisabledMessage" Margin="0,10,0,0" FontStyle="Italic" Visibility="Collapsed">
                 <Run Text="Application is not able to get location data. Go to " />

--- a/Samples/Geolocation/cs/GeolocationCS/Scenario7_ForegroundVisits.xaml.cs
+++ b/Samples/Geolocation/cs/GeolocationCS/Scenario7_ForegroundVisits.xaml.cs
@@ -151,12 +151,14 @@ namespace GeolocationCS
                 ScenarioOutput_Latitude.Text   = "No data";
                 ScenarioOutput_Longitude.Text  = "No data";
                 ScenarioOutput_Accuracy.Text   = "No data";
+                ScenarioOutput_IsRemoteSource.Text = "No data";
             }
             else
             {
                 ScenarioOutput_Latitude.Text    = visit.Position.Coordinate.Point.Position.Latitude.ToString();
                 ScenarioOutput_Longitude.Text   = visit.Position.Coordinate.Point.Position.Longitude.ToString();
                 ScenarioOutput_Accuracy.Text    = visit.Position.Coordinate.Accuracy.ToString();
+                ScenarioOutput_IsRemoteSource.Text = visit.Position.Coordinate.IsRemoteSource.ToString();
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Note that nontrivial changes will need to be reviewed by the feature team and will take time. -->

## Description

Name of sample: GeoLocation

**Description**: 
There are some scenarios where the physical location of the devices does not represent the user’s real location (ie: user connected remotely to a machine).
To tackle those scenarios, location team allowing internal clients -like RemoteDesktop- to redirect a user’s location to a remote machine; which can then be used as the main source of positioning. 
This will enable location experiences on the remote machine with respect to the user’s location and not the device’s physical location.  

For example: A user that connects remotely to a VM in a datacenter can still discover printers around themselves and their location and not that of the datacenter’s VM.  
Similarly, in the future a user using a Windows device without location capabilities can allow location redirection from their phone or another more accurate location source.


## Testing
Using the sample app.

## Type of change
<!-- Select all that apply. -->
- [ ] Bug fix
- [x] New feature
- [ ] Porting to new language

## Supported platforms
Minimum OS version: 

<!-- Select all that apply. -->
- [x] All UWP platforms
- [x] Desktop
- [x] Holographic
- [x] IoT
- [x] Xbox
- [x] 10X

## Supported languages
<!-- Select all that apply. -->
<!-- If the sample is available in more than one language, make sure your change applies to all versions. -->
<!-- C++/CX, JavaScript, and Visual Basic samples are no longer being maintained. -->
<!-- They are archived when the underlying sample changes. C++/CX samples are ported to C++/WinRT. -->
- [x] C#
- [x] C++/WinRT

## Additional remarks
<!-- Optional. -->
