### PR TITLE
Simple3DGameDX: Fix failing C++/WinRT build.

### DIFF
--- a/Samples/Simple3DGameDX/cppwinrt/Simple3DGameDX.vcxproj
+++ b/Samples/Simple3DGameDX/cppwinrt/Simple3DGameDX.vcxproj
@@ -68,7 +68,7 @@
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <WarningLevel>Level4</WarningLevel>

--- a/Samples/Simple3DGameDX/cppwinrt/pch.h
+++ b/Samples/Simple3DGameDX/cppwinrt/pch.h
@@ -32,3 +32,5 @@
 #include <mfidl.h>
 #include <mfapi.h>
 #include <mfreadwrite.h>
+
+#include <iterator>


### PR DESCRIPTION
Thousands of errors which meant headers were not found, and one error about `back_inserter` not in namespace `std`.

## Description

Name of sample: Simple3DGameDX (C++/WinRT version, .sln in sub-directory 'cppwinrt')

1. Change precompiled header setting to `Create(/Yc)`
2. `#include <iterator>` in pch.h

## Testing

Microsoft Visual Studio Community 2019
Version 16.8.5

Windows 10 Pro
OS Build 19041.804

## Type of change
<!-- Select all that apply. -->
- [x] Bug fix
- [ ] New feature
- [ ] Porting to new language

## Supported platforms
Minimum OS version: (example: 18362)

<!-- Select all that apply. -->
- [ ] All UWP platforms
- [x] Desktop
- [ ] Holographic
- [ ] IoT
- [ ] Xbox
- [ ] 10X

## Supported languages
<!-- Select all that apply. -->
<!-- If the sample is available in more than one language, make sure your change applies to all versions. -->
<!-- C++/CX, JavaScript, and Visual Basic samples are no longer being maintained. -->
<!-- They are archived when the underlying sample changes. C++/CX samples are ported to C++/WinRT. -->
- [ ] C#
- [x] C++/WinRT

## Additional remarks
<!-- Optional. -->
