### PR TITLE
Update README ZIP links to work again after branch rename from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This repo contains the samples that demonstrate the API usage patterns for the Universal Windows Platform (UWP) in the Windows Software Development Kit (SDK) for Windows 10. These code samples were created with the Universal Windows Platform templates available in Visual Studio, and are designed to run on desktop, mobile, and future devices that support the Universal Windows Platform.
 
 > **Note:** If you are unfamiliar with Git and GitHub, you can download the entire collection as a 
-> [ZIP file](https://github.com/Microsoft/Windows-universal-samples/archive/master.zip), but be 
+> [ZIP file](https://github.com/Microsoft/Windows-universal-samples/archive/main.zip), but be 
 > sure to unzip everything to access shared dependencies. For more info on working with the ZIP file, 
 > the samples collection, and GitHub, see [Get the UWP samples from GitHub](https://aka.ms/ovu2uq). 
 > For more samples, see the [Samples portal](https://aka.ms/winsamples) on the Windows Dev Center. 
@@ -26,7 +26,7 @@ Additionally, to stay on top of the latest updates to Windows and the developmen
 
 The easiest way to use these samples without using Git is to download the zip file containing the current version (using the following link or by clicking the "Download ZIP" button on the repo page). You can then unzip the entire archive and use the samples in Visual Studio.
 
-   [Download the samples ZIP](../../archive/master.zip)
+   [Download the samples ZIP](../../archive/main.zip)
 
    **Notes:** 
    * Before you unzip the archive, right-click it, select **Properties**, and then select **Unblock**.


### PR DESCRIPTION
This resolves Issue #1304 by updating the links for ZIP downloads to use the proper branch name, main.

https://github.com/microsoft/Windows-universal-samples/issues/1304

No samples changed, validated new URL correctly points to ZIP file and can download again.
