### PR TITLE
ExtendedExecution: Remove confusing suspending deferral field

### DIFF
--- a/Samples/ExtendedExecution/cs/Scenario2_SavingDataReason.xaml.cs
+++ b/Samples/ExtendedExecution/cs/Scenario2_SavingDataReason.xaml.cs
@@ -30,7 +30,6 @@ namespace SDKTemplate
         private MainPage rootPage = MainPage.Current;
 
         private CancellationTokenSource cancellationTokenSource;
-        private SuspendingDeferral suspendDeferral;
 
         public SavingDataReason()
         {
@@ -50,7 +49,7 @@ namespace SDKTemplate
 
         private async void OnSuspending(object sender, SuspendingEventArgs args)
         {
-            suspendDeferral = args.SuspendingOperation.GetDeferral();
+            var suspendDeferral = args.SuspendingOperation.GetDeferral();
 
             rootPage.NotifyUser("", NotifyType.StatusMessage);
 
@@ -112,9 +111,6 @@ namespace SDKTemplate
                         rootPage.NotifyUser("Extended execution revoked due to system policy.", NotifyType.StatusMessage);
                         break;
                 }
-
-                suspendDeferral?.Complete();
-                suspendDeferral = null;
             });
         }
     }


### PR DESCRIPTION
When I first saw this sample, I thought there must be some special reasons that the `suspendDeferral` should be hold as a field. And there must be some reasons we have to call `suspendDeferral?.Complete()` in two different places. But after some investigation, I found I don't have to call that in the revoked callback. It will finally be called in `OnSuspending`.