### PR TITLE
Fixed HolographicSpatialStage build errors

### DIFF
--- a/Samples/HolographicSpatialStage/cpp/SpatialStageManager.cpp
+++ b/Samples/HolographicSpatialStage/cpp/SpatialStageManager.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "SpatialStageManager.h"
+#include <functional>
 
 using namespace HolographicSpatialStage;
 
@@ -143,9 +144,9 @@ std::vector<float3> SpatialStageManager::CreateCircle(float3 center, float radiu
         float radiansThisIteration = radians * float(i) / float(divisions);
         vertices[i] =
             {
-                center.x + (radius * -cos(radiansThisIteration)), 
+                static_cast<float>(center.x + (radius * -cos(radiansThisIteration))), 
                 center.y,
-                center.z + (radius * -sin(radiansThisIteration))
+                static_cast<float>(center.z + (radius * -sin(radiansThisIteration)))
             };
     }
 


### PR DESCRIPTION
SpatialStageManager.cpp(20,95): error C2065: '_1': undeclared identifier
SpatialStageManager.cpp(146,26): error C2398: Element '1': conversion from 'double' to 'float' requires a narrowing conversion

<!-- Provide a general summary of your changes in the Title above -->
<!-- Note that nontrivial changes will need to be reviewed by the feature team and will take time. -->

## Description

Name of sample: (example: ResizeAppView, or proposed name of new sample)

<!-- Describe your changes in detail -->
<!-- If this change fixes an open issue, please link to the issue here. -->

## Testing
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran. -->

## Type of change
<!-- Select all that apply. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Porting to new language

## Supported platforms
Minimum OS version: (example: 18362)

<!-- Select all that apply. -->
- [ ] All UWP platforms
- [ ] Desktop
- [ ] Holographic
- [ ] IoT
- [ ] Xbox
- [ ] 10X

## Supported languages
<!-- Select all that apply. -->
<!-- If the sample is available in more than one language, make sure your change applies to all versions. -->
<!-- C++/CX, JavaScript, and Visual Basic samples are no longer being maintained. -->
<!-- They are archived when the underlying sample changes. C++/CX samples are ported to C++/WinRT. -->
- [ ] C#
- [ ] C++/WinRT

## Additional remarks
<!-- Optional. -->
