### PR TITLE
BluetoothLE: Bugfix for removing the notification/indication handler

### DIFF
--- a/Samples/BluetoothLE/cs/Scenario2_Client.xaml.cs
+++ b/Samples/BluetoothLE/cs/Scenario2_Client.xaml.cs
@@ -423,7 +423,6 @@ namespace SDKTemplate
                                 GattClientCharacteristicConfigurationDescriptorValue.None);
                     if (result == GattCommunicationStatus.Success)
                     {
-                        subscribedForNotifications = false;
                         RemoveValueChangedHandler();
                         rootPage.NotifyUser("Successfully un-registered for notifications", NotifyType.StatusMessage);
                     }


### PR DESCRIPTION
Bugfix to properly removed characteristic notification/indication handlers upon unsubscribing.

## Description

Name of sample: BluetoothLE (C# App)

Previous behavior was to receive duplicate characteristic packets proportional to the number of times the characteristic had been subscribed/unsubscribed w/in a given app launch.

## Testing
Added code to store packets received from the peripheral. Configured the peripheral to send the value of a counter which updates every second. Verified that duplicate packets are captured with every user Subscribe/Unsubscribe action. e.g. upon enabling subscribe for a given characteristic three times, I receive 3 packets with the same content.

## Type of change
<!-- Select all that apply. -->
- [ X ] Bug fix
- [ ] New feature
- [ ] Porting to new language

## Supported platforms
Minimum OS version: (example: 18362)

<!-- Select all that apply. -->
- [ X ] All UWP platforms
- [ ] Desktop
- [ ] Holographic
- [ ] IoT
- [ ] Xbox
- [ ] 10X

## Supported languages
<!-- Select all that apply. -->
<!-- If the sample is available in more than one language, make sure your change applies to all versions. -->
<!-- C++/CX, JavaScript, and Visual Basic samples are no longer being maintained. -->
<!-- They are archived when the underlying sample changes. C++/CX samples are ported to C++/WinRT. -->
- [ X ] C#
- [ ] C++/WinRT

## Additional remarks
None