### PR TITLE
Adding vp9 to MediaTranscoding sample

### DIFF
--- a/Samples/MediaTranscoding/cpp/MediaTranscoding.vcxproj
+++ b/Samples/MediaTranscoding/cpp/MediaTranscoding.vcxproj
@@ -11,7 +11,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.18362.0</WindowsTargetPlatformMinVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
   </PropertyGroup>

--- a/Samples/MediaTranscoding/cpp/Scenario1_Default.xaml.cpp
+++ b/Samples/MediaTranscoding/cpp/Scenario1_Default.xaml.cpp
@@ -114,6 +114,10 @@ void Scenario1_Default::GetPresetProfile(ComboBox^ comboBox)
     {
         _Profile = MediaEncodingProfile::CreateWmv(videoEncodingProfile);
     }
+    else if (_OutputType == "VP9")
+    {
+        _Profile = MediaEncodingProfile::CreateVp9(videoEncodingProfile);
+    }
     else
     {
         _Profile = MediaEncodingProfile::CreateMp4(videoEncodingProfile);
@@ -432,6 +436,11 @@ void Scenario1_Default::OnTargetFormatChanged(Object^ sender, SelectionChangedEv
 
         // Disable NTSC and PAL profiles as non-square pixel aspect ratios are not supported by AVI
         DisableNonSquarePARProfiles();
+        break;
+    case 3:
+        _OutputFileExtension = ".mp4";
+        _OutputType = "VP9";
+        EnableNonSquarePARProfiles();
         break;
     default:
         _OutputFileExtension = ".mp4";

--- a/Samples/MediaTranscoding/cpp/Scenario1_Default.xaml.cpp
+++ b/Samples/MediaTranscoding/cpp/Scenario1_Default.xaml.cpp
@@ -118,6 +118,10 @@ void Scenario1_Default::GetPresetProfile(ComboBox^ comboBox)
     {
         _Profile = MediaEncodingProfile::CreateVp9(videoEncodingProfile);
     }
+    else if (_OutputType == "AV1")
+    {
+        _Profile = MediaEncodingProfile::CreateAv1(videoEncodingProfile);
+    }
     else
     {
         _Profile = MediaEncodingProfile::CreateMp4(videoEncodingProfile);
@@ -440,6 +444,11 @@ void Scenario1_Default::OnTargetFormatChanged(Object^ sender, SelectionChangedEv
     case 3:
         _OutputFileExtension = ".mp4";
         _OutputType = "VP9";
+        EnableNonSquarePARProfiles();
+        break;
+    case 4:
+        _OutputFileExtension = ".mp4";
+        _OutputType = "AV1";
         EnableNonSquarePARProfiles();
         break;
     default:

--- a/Samples/MediaTranscoding/cs/MediaTranscoding.csproj
+++ b/Samples/MediaTranscoding/cs/MediaTranscoding.csproj
@@ -14,7 +14,7 @@
     <AssemblyName>MediaTranscodingSample</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/MediaTranscoding/cs/Scenario1_Default.xaml.cs
+++ b/Samples/MediaTranscoding/cs/Scenario1_Default.xaml.cs
@@ -165,6 +165,9 @@ namespace SDKTemplate
                 case "WMV":
                     _Profile = MediaEncodingProfile.CreateWmv(videoEncodingProfile);
                     break;
+                case "VP9":
+                    _Profile = MediaEncodingProfile.CreateVp9(videoEncodingProfile);
+                    break;
                 default:
                     _Profile = MediaEncodingProfile.CreateMp4(videoEncodingProfile);
                     break;
@@ -301,6 +304,11 @@ namespace SDKTemplate
 
                     // Disable NTSC and PAL profiles as non-square pixel aspect ratios are not supported by AVI
                     DisableNonSquarePARProfiles();
+                    break;
+                case 3:
+                    _OutputType = "VP9";
+                    _OutputFileExtension = ".mp4";
+                    EnableNonSquarePARProfiles();
                     break;
                 default:
                     _OutputType = "MP4";

--- a/Samples/MediaTranscoding/cs/Scenario1_Default.xaml.cs
+++ b/Samples/MediaTranscoding/cs/Scenario1_Default.xaml.cs
@@ -93,7 +93,15 @@ namespace SDKTemplate
             {
                 if ((_InputFile != null) && (_OutputFile != null))
                 {
+
+                    // TBD - Test with hardware acceleration disabled
+                    _Transcoder.HardwareAccelerationEnabled = false;
+
                     var preparedTranscodeResult = await _Transcoder.PrepareFileTranscodeAsync(_InputFile, _OutputFile, _Profile);
+
+                    // TBD - Test with hardware acceleration disabled
+                    _Transcoder.HardwareAccelerationEnabled = false;
+
 
                     if (EnableMrfCrf444.IsChecked.HasValue && (bool)EnableMrfCrf444.IsChecked)
                     {

--- a/Samples/MediaTranscoding/cs/Scenario1_Default.xaml.cs
+++ b/Samples/MediaTranscoding/cs/Scenario1_Default.xaml.cs
@@ -168,6 +168,9 @@ namespace SDKTemplate
                 case "VP9":
                     _Profile = MediaEncodingProfile.CreateVp9(videoEncodingProfile);
                     break;
+                case "AV1":
+                    _Profile = MediaEncodingProfile.CreateAv1(videoEncodingProfile);
+                    break;
                 default:
                     _Profile = MediaEncodingProfile.CreateMp4(videoEncodingProfile);
                     break;
@@ -307,6 +310,11 @@ namespace SDKTemplate
                     break;
                 case 3:
                     _OutputType = "VP9";
+                    _OutputFileExtension = ".mp4";
+                    EnableNonSquarePARProfiles();
+                    break;
+                case 4:
+                    _OutputType = "AV1";
                     _OutputFileExtension = ".mp4";
                     EnableNonSquarePARProfiles();
                     break;

--- a/Samples/MediaTranscoding/shared/Scenario1_Default.xaml
+++ b/Samples/MediaTranscoding/shared/Scenario1_Default.xaml
@@ -52,6 +52,7 @@
                     <ComboBoxItem Content="VC-1/WMV"/>
                     <ComboBoxItem Content="Uncompressed/AVI"/>
                     <ComboBoxItem Content="VP9/MP4"/>
+                    <ComboBoxItem Content="AV1/MP4"/>
                 </ComboBox>
                 <TextBlock Grid.Row="5" Grid.Column="0" Text="Transcode Profile: "></TextBlock>
                 <ComboBox Grid.Row="5" Grid.Column="1" Margin="4,2" x:Name="ProfileSelect" HorizontalAlignment="Left" Width="180" Height="Auto" SelectedIndex="2" >

--- a/Samples/MediaTranscoding/shared/Scenario1_Default.xaml
+++ b/Samples/MediaTranscoding/shared/Scenario1_Default.xaml
@@ -51,6 +51,7 @@
                     <ComboBoxItem Content="H.264/MP4"/>
                     <ComboBoxItem Content="VC-1/WMV"/>
                     <ComboBoxItem Content="Uncompressed/AVI"/>
+                    <ComboBoxItem Content="VP9/MP4"/>
                 </ComboBox>
                 <TextBlock Grid.Row="5" Grid.Column="0" Text="Transcode Profile: "></TextBlock>
                 <ComboBox Grid.Row="5" Grid.Column="1" Margin="4,2" x:Name="ProfileSelect" HorizontalAlignment="Left" Width="180" Height="Auto" SelectedIndex="2" >


### PR DESCRIPTION
## Description

Name of sample: MediaTranscoding

I added VP9 codec as an option for transcoding. I copied the existing pattern for other codecs (e.g. mp4)

## Testing
I'm doing ad hoc testing and, at the time I'm creating the draft PR, the VP9 transcoding is failing gracefully. 

## Type of change
<!-- Select all that apply. -->
- [ ] Bug fix
- [ x] New feature
- [ ] Porting to new language

## Supported platforms
Minimum OS version: (example: 18362)

<!-- Select all that apply. -->
- [ ] All UWP platforms
- [x ] Desktop
- [ ] Holographic
- [ ] IoT
- [ ] Xbox
- [ ] 10X

## Supported languages
<!-- Select all that apply. -->
<!-- If the sample is available in more than one language, make sure your change applies to all versions. -->
<!-- C++/CX, JavaScript, and Visual Basic samples are no longer being maintained. -->
<!-- They are archived when the underlying sample changes. C++/CX samples are ported to C++/WinRT. -->
- [x ] C#
- [ ] C++/WinRT



## Additional remarks
I'm updating the C++/CX sample, despite the supported languages instructions above. I'll consult with the feature team about this before taking the PR out of draft.
