### PR TITLE
Correction in DWriteLineSpacingModes ReadMe.md

### DIFF
--- a/Samples/DWriteLineSpacingModes/README.md
+++ b/Samples/DWriteLineSpacingModes/README.md
@@ -51,8 +51,8 @@ Within the DWriteTextLayoutImplementation project, the following files are signi
 * The TextLayout.h/.cpp files wrap the DirectWrite text layout and related line spacing APIs. 
 * The TextLayoutImageSource.h/.cpp files implement a XAML SurfaceImageSource using DirectX APIs for rendering the text layout.
 
-### DWriteTextLayoutCloudFont project
-Within the DWriteTextLayoutCloudFont project, the following files are significant:
+### DWriteLineSpacingModes project
+Within the DWriteLineSpacingModes project, the following files are significant:
 
 * The Scenario1\_DefaultSpacing.\*, Scenario2\_UniformSpacing.\* and Scenario3\_ProportionalSpacing.\* files each demonstrate a different line spacing method.
 


### PR DESCRIPTION
DWriteLineSpacingModes: fix name type in README

<!-- Provide a general summary of your changes in the Title above -->
<!-- Note that nontrivial changes will need to be reviewed by the feature team and will take time. -->

## Description

Name of sample: DWriteLineSpacingModes

In the DWriteLineSpacingModes sample, the README.md file had incorrect info due to copy/paste error from a different DirectWrite sample.

## Testing
n/a: no code changes

## Type of change
<!-- Select all that apply. -->
- [x] Bug fix -- **documentation bug**
- [ ] New feature
- [ ] Porting to new language

## Supported platforms
Minimum OS version: 10.0.22621.0

<!-- Select all that apply. -->
- [x] All UWP platforms
- [x] Desktop
- [x] Holographic
- [x] IoT
- [x] Xbox
- [x] 10X

## Supported languages
<!-- Select all that apply. -->
<!-- If the sample is available in more than one language, make sure your change applies to all versions. -->
<!-- C++/CX, JavaScript, and Visual Basic samples are no longer being maintained. -->
<!-- They are archived when the underlying sample changes. C++/CX samples are ported to C++/WinRT. -->
- [ ] C#
- [ ] C++/WinRT
- [x] C++/CX (unchanged)

## Additional remarks
This is a minor documentation fix.